### PR TITLE
making ENV vars and github URL configurable

### DIFF
--- a/Sources/Imperial/Authenticatable/FederatedServiceTokens.swift
+++ b/Sources/Imperial/Authenticatable/FederatedServiceTokens.swift
@@ -39,13 +39,13 @@ from environment variables and stores them.
 public protocol FederatedServiceTokens {
     
     /// The name of the environment variable that has the client ID.
-    var idEnvKey: String { get }
+    static var idEnvKey: String { get set }
     
     /// The client ID for the OAuth provider that the service is connected to.
-    var clientID: String { get }
+    var clientID: String { get set }
     
     /// The name of the environment variable that has the client secret.
-    var secretEnvKey: String { get }
+    static var secretEnvKey: String { get }
     
     /// The client secret for the OAuth provider that the service is connected to.
     var clientSecret: String { get }

--- a/Sources/Imperial/Services/Facebook/FacebookAuth.swift
+++ b/Sources/Imperial/Services/Facebook/FacebookAuth.swift
@@ -1,16 +1,16 @@
 import Vapor
 
 public class FacebookAuth: FederatedServiceTokens {
-    public var idEnvKey: String = "FACEBOOK_CLIENT_ID"
-    public var secretEnvKey: String = "FACEBOOK_CLIENT_SECRET"
+    public static var idEnvKey: String = "FACEBOOK_CLIENT_ID"
+    public static var secretEnvKey: String = "FACEBOOK_CLIENT_SECRET"
     public var clientID: String
     public var clientSecret: String
 
     public required init() throws {
-        let idError = ImperialError.missingEnvVar(idEnvKey)
-        let secretError = ImperialError.missingEnvVar(secretEnvKey)
+        let idError = ImperialError.missingEnvVar(FacebookAuth.idEnvKey)
+        let secretError = ImperialError.missingEnvVar(FacebookAuth.secretEnvKey)
 
-        self.clientID = try Environment.get(idEnvKey).value(or: idError)
-        self.clientSecret = try Environment.get(secretEnvKey).value(or: secretError)
+        self.clientID = try Environment.get(FacebookAuth.idEnvKey).value(or: idError)
+        self.clientSecret = try Environment.get(FacebookAuth.secretEnvKey).value(or: secretError)
     }
 }

--- a/Sources/Imperial/Services/GitHub/GitHubAuth.swift
+++ b/Sources/Imperial/Services/GitHub/GitHubAuth.swift
@@ -1,16 +1,16 @@
 import Vapor
 
 public class GitHubAuth: FederatedServiceTokens {
-    public var idEnvKey: String = "GITHUB_CLIENT_ID"
-    public var secretEnvKey: String = "GITHUB_CLIENT_SECRET"
+    public static var idEnvKey: String = "GITHUB_CLIENT_ID"
+    public static var secretEnvKey: String = "GITHUB_CLIENT_SECRET"
     public var clientID: String
     public var clientSecret: String
     
     public required init() throws {
-        let idError = ImperialError.missingEnvVar(idEnvKey)
-        let secretError = ImperialError.missingEnvVar(secretEnvKey)
+        let idError = ImperialError.missingEnvVar(GitHubAuth.idEnvKey)
+        let secretError = ImperialError.missingEnvVar(GitHubAuth.secretEnvKey)
         
-        self.clientID = try Environment.get(idEnvKey).value(or: idError)
-        self.clientSecret = try Environment.get(secretEnvKey).value(or: secretError)
+        self.clientID = try Environment.get(GitHubAuth.idEnvKey).value(or: idError)
+        self.clientSecret = try Environment.get(GitHubAuth.secretEnvKey).value(or: secretError)
     }
 }

--- a/Sources/Imperial/Services/GitHub/GitHubRouter.swift
+++ b/Sources/Imperial/Services/GitHub/GitHubRouter.swift
@@ -2,13 +2,14 @@ import Vapor
 import Foundation
 
 public class GitHubRouter: FederatedServiceRouter {
+    public static var baseURL: String = "https://github.com/"
     public let tokens: FederatedServiceTokens
     public let callbackCompletion: (Request, String)throws -> (Future<ResponseEncodable>)
     public var scope: [String] = []
     public let callbackURL: String
-    public let accessTokenURL: String = "https://github.com/login/oauth/access_token"
+    public let accessTokenURL: String = "\(GitHubRouter.baseURL)login/oauth/access_token"
     public var authURL: String {
-        return "https://github.com/login/oauth/authorize?" +
+        return "\(GitHubRouter.baseURL)login/oauth/authorize?" +
                "scope=\(scope.joined(separator: "%20"))&" +
                "client_id=\(self.tokens.clientID)"
     }

--- a/Sources/Imperial/Services/Google/GoogleAuth.swift
+++ b/Sources/Imperial/Services/Google/GoogleAuth.swift
@@ -1,16 +1,16 @@
 import Vapor
 
 public class GoogleAuth: FederatedServiceTokens {
-    public var idEnvKey: String = "GOOGLE_CLIENT_ID"
-    public var secretEnvKey: String = "GOOGLE_CLIENT_SECRET"
+    public static var idEnvKey: String = "GOOGLE_CLIENT_ID"
+    public static var secretEnvKey: String = "GOOGLE_CLIENT_SECRET"
     public var clientID: String
     public var clientSecret: String
     
     public required init() throws {
-        let idError = ImperialError.missingEnvVar(idEnvKey)
-        let secretError = ImperialError.missingEnvVar(secretEnvKey)
+        let idError = ImperialError.missingEnvVar(GoogleAuth.idEnvKey)
+        let secretError = ImperialError.missingEnvVar(GoogleAuth.secretEnvKey)
         
-        self.clientID = try Environment.get(idEnvKey).value(or: idError)
-        self.clientSecret = try Environment.get(secretEnvKey).value(or: secretError)
+        self.clientID = try Environment.get(GoogleAuth.idEnvKey).value(or: idError)
+        self.clientSecret = try Environment.get(GoogleAuth.secretEnvKey).value(or: secretError)
     }
 }

--- a/Sources/Imperial/Services/GoogleJWT/GoogleJWTAuth.swift
+++ b/Sources/Imperial/Services/GoogleJWT/GoogleJWTAuth.swift
@@ -1,16 +1,16 @@
 import Vapor
 
 public class GoogleJWTAuth: FederatedServiceTokens {
-    public var idEnvKey: String = "GOOGLEJWT_CLIENT_EMAIL"
-    public var secretEnvKey: String = "GOOGLEJWT_CLIENT_SECRET"
+    public static var idEnvKey: String = "GOOGLEJWT_CLIENT_EMAIL"
+    public static var secretEnvKey: String = "GOOGLEJWT_CLIENT_SECRET"
     public var clientID: String
     public var clientSecret: String
     
     public required init() throws {
-        let idError = ImperialError.missingEnvVar(idEnvKey)
-        let secretError = ImperialError.missingEnvVar(secretEnvKey)
+        let idError = ImperialError.missingEnvVar(GoogleJWTAuth.idEnvKey)
+        let secretError = ImperialError.missingEnvVar(GoogleJWTAuth.secretEnvKey)
         
-        self.clientID = try Environment.get(idEnvKey).value(or: idError)
-        self.clientSecret = try Environment.get(secretEnvKey).value(or: secretError)
+        self.clientID = try Environment.get(GoogleJWTAuth.idEnvKey).value(or: idError)
+        self.clientSecret = try Environment.get(GoogleJWTAuth.secretEnvKey).value(or: secretError)
     }
 }

--- a/Sources/Imperial/Services/Shopify/ShopifyAuth.swift
+++ b/Sources/Imperial/Services/Shopify/ShopifyAuth.swift
@@ -1,16 +1,16 @@
 import Vapor
 
 public class ShopifyAuth: FederatedServiceTokens {
-	public var idEnvKey: String = "SHOPIFY_CLIENT_ID"
-	public var secretEnvKey: String = "SHOPIFY_CLIENT_SECRET"
+	public static var idEnvKey: String = "SHOPIFY_CLIENT_ID"
+	public static var secretEnvKey: String = "SHOPIFY_CLIENT_SECRET"
 	public var clientID: String
 	public var clientSecret: String
 	
 	public required init() throws {
-		let idError = ImperialError.missingEnvVar(idEnvKey)
-		let secretError = ImperialError.missingEnvVar(secretEnvKey)
+		let idError = ImperialError.missingEnvVar(ShopifyAuth.idEnvKey)
+		let secretError = ImperialError.missingEnvVar(ShopifyAuth.secretEnvKey)
 		
-		self.clientID = try Environment.get(idEnvKey).value(or: idError)
-		self.clientSecret = try Environment.get(secretEnvKey).value(or: secretError)
+		self.clientID = try Environment.get(ShopifyAuth.idEnvKey).value(or: idError)
+		self.clientSecret = try Environment.get(ShopifyAuth.secretEnvKey).value(or: secretError)
 	}
 }


### PR DESCRIPTION
I don't see other way to enable these without rewriting the whole structure of the library ... if I may, I would suggest this or similar solution for now and to rethink if we could upgrade the whole thing a bit to allow more flexible customisations for a major release?

These changes are breaking (on public properties) although I don't think anyone would be accessing them or using them in any way ...