### PR TITLE
Adding authenticate callback method

### DIFF
--- a/Sources/Imperial/ServiceRegister.swift
+++ b/Sources/Imperial/ServiceRegister.swift
@@ -7,7 +7,8 @@ extension Router {
     ///
     /// - Parameters:
     ///   - provider: The provider who's router will be used.
-    ///   - authUrl: The path to navigate to to authenticate.
+    ///   - authUrl: The path to navigate to authenticate.
+    ///   - authenticateCallback: Execute custom code within the authenticate closure before redirection.
     ///   - callback: The path or URL that the provider with
     ///     redirect to when authentication completes.
     ///   - scope: The scopes to get access to on authentication.
@@ -16,11 +17,12 @@ extension Router {
     public func oAuth<OAuthProvider>(
         from provider: OAuthProvider.Type,
         authenticate authUrl: String,
+        authenticateCallback: ((Request) -> (Future<Void>))? = nil,
         callback: String,
         scope: [String] = [],
         completion: @escaping (Request, String)throws -> Future<ResponseEncodable>
     )throws where OAuthProvider: FederatedService {
-        _ = try OAuthProvider(router: self, authenticate: authUrl, callback: callback, scope: scope, completion: completion)
+        _ = try OAuthProvider(router: self, authenticate: authUrl, authenticateCallback: authenticateCallback, callback: callback, scope: scope, completion: completion)
     }
     
     /// Registers an OAuth provider's router with
@@ -28,7 +30,8 @@ extension Router {
     ///
     /// - Parameters:
     ///   - provider: The provider who's router will be used.
-    ///   - authUrl: The path to navigate to to authenticate.
+    ///   - authUrl: The path to navigate to authenticate.
+    ///   - authenticateCallback: Execute custom code within the authenticate closure before redirection.
     ///   - callback: The path or URL that the provider with
     ///     redirect to when authentication completes.
     ///   - scope: The scopes to get access to on authentication.
@@ -36,11 +39,12 @@ extension Router {
     public func oAuth<OAuthProvider>(
         from provider: OAuthProvider.Type,
         authenticate authUrl: String,
+        authenticateCallback: ((Request) -> (Future<Void>))? = nil,
         callback: String,
         scope: [String] = [],
         redirect redirectURL: String
     )throws where OAuthProvider: FederatedService {
-        try self.oAuth(from: OAuthProvider.self, authenticate: authUrl, callback: callback, scope: scope) { (request, _) in
+        try self.oAuth(from: OAuthProvider.self, authenticate: authUrl, authenticateCallback: authenticateCallback, callback: callback, scope: scope) { (request, _) in
             let redirect: Response = request.redirect(to: redirectURL)
             return request.eventLoop.newSucceededFuture(result: redirect)
         }

--- a/Sources/Imperial/Services/Facebook/Facebook.swift
+++ b/Sources/Imperial/Services/Facebook/Facebook.swift
@@ -8,6 +8,7 @@ public class Facebook: FederatedService {
     public required init(
         router: Router,
         authenticate: String,
+        authenticateCallback: ((Request) -> (Future<Void>))?,
         callback: String,
         scope: [String] = [],
         completion: @escaping (Request, String)throws -> (Future<ResponseEncodable>)
@@ -16,7 +17,7 @@ public class Facebook: FederatedService {
         self.tokens = self.router.tokens
 
         self.router.scope = scope
-        try self.router.configureRoutes(withAuthURL: authenticate, on: router)
+        try self.router.configureRoutes(withAuthURL: authenticate, authenticateCallback: authenticateCallback, on: router)
 
         OAuthService.register(.facebook)
     }

--- a/Sources/Imperial/Services/FederatedService.swift
+++ b/Sources/Imperial/Services/FederatedService.swift
@@ -19,7 +19,7 @@ public class Service: FederatedService {
         self.tokens = self.router.tokens
 
         self.router.scope = scope
-        try self.router.configureRoutes(withAuthURL: authenticate)
+        try self.router.configureRoutes(withAuthURL: authenticate, authenticateCallback: authenticateCallback, on: router)
 
         Service.register(.service)
     }
@@ -38,9 +38,10 @@ public protocol FederatedService {
     ///
     /// - Parameters:
     ///   - authenticate: The path for the route that will redirect the user to the OAuth provider for authentication.
+    ///   - authenticateCallback: Execute custom code within the authenticate closure before redirection.
     ///   - callback: The path (or URI) for the route that the provider will call when the user authenticates.
     ///   - scope: The scopes to send to the provider to request access to.
     ///   - completion: The completion handler that will fire at the end of the callback route. The access token is passed into the callback and the response that is returned will be returned from the callback route. This will usually be a redirect back to the app.
     /// - Throws: Any errors that occur in the implementation.
-    init(router: Router, authenticate: String, callback: String, scope: [String], completion: @escaping (Request, String)throws -> (Future<ResponseEncodable>))throws
+    init(router: Router, authenticate: String, authenticateCallback: ((Request) -> (Future<Void>))?, callback: String, scope: [String], completion: @escaping (Request, String)throws -> (Future<ResponseEncodable>))throws
 }

--- a/Sources/Imperial/Services/GitHub/GitHub.swift
+++ b/Sources/Imperial/Services/GitHub/GitHub.swift
@@ -8,6 +8,7 @@ public class GitHub: FederatedService {
     public required init(
         router: Router,
         authenticate: String,
+        authenticateCallback: ((Request) -> (Future<Void>))?,
         callback: String,
         scope: [String] = [],
         completion: @escaping (Request, String)throws -> (Future<ResponseEncodable>)
@@ -16,7 +17,7 @@ public class GitHub: FederatedService {
         self.tokens = self.router.tokens
         
         self.router.scope = scope
-        try self.router.configureRoutes(withAuthURL: authenticate, on: router)
+        try self.router.configureRoutes(withAuthURL: authenticate, authenticateCallback: authenticateCallback, on: router)
         
         OAuthService.register(.github)
     }

--- a/Sources/Imperial/Services/Google/Google.swift
+++ b/Sources/Imperial/Services/Google/Google.swift
@@ -8,6 +8,7 @@ public class Google: FederatedService {
     public required init(
         router: Router,
         authenticate: String,
+        authenticateCallback: ((Request) -> (Future<Void>))?,
         callback: String,
         scope: [String] = [],
         completion: @escaping (Request, String)throws -> (Future<ResponseEncodable>)
@@ -16,7 +17,7 @@ public class Google: FederatedService {
         self.tokens = self.router.tokens
         
         self.router.scope = scope
-        try self.router.configureRoutes(withAuthURL: authenticate, on: router)
+        try self.router.configureRoutes(withAuthURL: authenticate, authenticateCallback: authenticateCallback, on: router)
         
         OAuthService.register(.google)
     }

--- a/Sources/Imperial/Services/GoogleJWT/GoogleJWT.swift
+++ b/Sources/Imperial/Services/GoogleJWT/GoogleJWT.swift
@@ -8,6 +8,7 @@ public class GoogleJWT: FederatedService {
     public required init(
         router: Router,
         authenticate: String,
+        authenticateCallback: ((Request) -> (Future<Void>))?,
         callback: String,
         scope: [String] = [],
         completion: @escaping (Request, String)throws -> (Future<ResponseEncodable>)
@@ -16,7 +17,7 @@ public class GoogleJWT: FederatedService {
         self.tokens = self.router.tokens
         
         self.router.scope = scope
-        try self.router.configureRoutes(withAuthURL: authenticate, on: router)
+        try self.router.configureRoutes(withAuthURL: authenticate, authenticateCallback: authenticateCallback, on: router)
         
         OAuthService.register(.google)
     }

--- a/Sources/Imperial/Services/Shopify/Shopify.swift
+++ b/Sources/Imperial/Services/Shopify/Shopify.swift
@@ -14,6 +14,7 @@ public class Shopify: FederatedService {
     
     public required init(router: Router,
                          authenticate: String,
+                         authenticateCallback: ((Request) -> (Future<Void>))?,
                          callback: String,
                          scope: [String],
                          completion: @escaping (Request, String) throws -> (EventLoopFuture<ResponseEncodable>)) throws {
@@ -21,6 +22,6 @@ public class Shopify: FederatedService {
         self.shopifyRouter = try ShopifyRouter(callback: callback, completion: completion)
         self.shopifyRouter.scope = scope
         
-        try self.router.configureRoutes(withAuthURL: authenticate, on: router)
+        try self.router.configureRoutes(withAuthURL: authenticate, authenticateCallback: authenticateCallback, on: router)
     }
 }


### PR DESCRIPTION
to allow save redirect link in a session for example ... without this, you won't be able to use this library in an API environment where you need to map user to the authorise object

The callback Future is there as you may need to save or cache data to the DB so with it we ensure we have enough time to execute our code