### PR TITLE
generate an authURL for shopify

### DIFF
--- a/Sources/Imperial/Routing/FederatedServiceRouter.swift
+++ b/Sources/Imperial/Routing/FederatedServiceRouter.swift
@@ -23,8 +23,7 @@ public protocol FederatedServiceRouter {
     var accessTokenURL: String { get }
     
     /// The URL of the page that the user will be redirected to to get the access token.
-    var authURL: String { get }
-    
+    func authURL(_ request: Request) throws -> String
     
     /// Creates an instence of the type implementing the protocol.
     ///
@@ -68,7 +67,7 @@ extension FederatedServiceRouter {
         
         router.get(callbackPath, use: callback)
         router.get(authURL) { req -> Future<Response> in
-            let redirect: Response = req.redirect(to: self.authURL)
+            let redirect: Response = req.redirect(to: try self.authURL(req))
             guard let authenticateCallback = authenticateCallback else {
                 return req.eventLoop.newSucceededFuture(result: redirect)
             }

--- a/Sources/Imperial/Services/GitHub/GitHubRouter.swift
+++ b/Sources/Imperial/Services/GitHub/GitHubRouter.swift
@@ -8,16 +8,17 @@ public class GitHubRouter: FederatedServiceRouter {
     public var scope: [String] = []
     public let callbackURL: String
     public let accessTokenURL: String = "\(GitHubRouter.baseURL)login/oauth/access_token"
-    public var authURL: String {
-        return "\(GitHubRouter.baseURL)login/oauth/authorize?" +
-               "scope=\(scope.joined(separator: "%20"))&" +
-               "client_id=\(self.tokens.clientID)"
-    }
     
     public required init(callback: String, completion: @escaping (Request, String)throws -> (Future<ResponseEncodable>)) throws {
         self.tokens = try GitHubAuth()
         self.callbackURL = callback
         self.callbackCompletion = completion
+    }
+    
+    public func authURL(_ request: Request) throws -> String {
+        return "\(GitHubRouter.baseURL)login/oauth/authorize?" +
+            "scope=\(scope.joined(separator: "%20"))&" +
+        "client_id=\(self.tokens.clientID)"
     }
     
     public func fetchToken(from request: Request)throws -> Future<String> {

--- a/Sources/Imperial/Services/Google/GoogleRouter.swift
+++ b/Sources/Imperial/Services/Google/GoogleRouter.swift
@@ -7,18 +7,19 @@ public class GoogleRouter: FederatedServiceRouter {
     public var scope: [String] = []
     public let callbackURL: String
     public let accessTokenURL: String = "https://www.googleapis.com/oauth2/v4/token"
-    public var authURL: String {
-        return "https://accounts.google.com/o/oauth2/auth?" +
-               "client_id=\(self.tokens.clientID)&" +
-               "redirect_uri=\(self.callbackURL)&" +
-               "scope=\(scope.joined(separator: "%20"))&" +
-               "response_type=code"
-    }
     
     public required init(callback: String, completion: @escaping (Request, String)throws -> (Future<ResponseEncodable>)) throws {
         self.tokens = try GoogleAuth()
         self.callbackURL = callback
         self.callbackCompletion = completion
+    }
+
+    public func authURL(_ request: Request) throws -> String {
+        return "https://accounts.google.com/o/oauth2/auth?" +
+            "client_id=\(self.tokens.clientID)&" +
+            "redirect_uri=\(self.callbackURL)&" +
+            "scope=\(scope.joined(separator: "%20"))&" +
+        "response_type=code"
     }
     
     public func fetchToken(from request: Request)throws -> Future<String> {

--- a/Sources/Imperial/Services/GoogleJWT/GoogleJWTRouter.swift
+++ b/Sources/Imperial/Services/GoogleJWT/GoogleJWTRouter.swift
@@ -18,6 +18,10 @@ public final class GoogleJWTRouter: FederatedServiceRouter {
         self.callbackCompletion = completion
     }
     
+    public func authURL(_ request: Request) throws -> String {
+        return authURL
+    }
+    
     public func fetchToken(from request: Request) throws -> EventLoopFuture<String> {
         let headers: HTTPHeaders = ["Content-Type": MediaType.urlEncodedForm.description]
         let token = try self.jwt()


### PR DESCRIPTION
Fixes: #36 

Changes the protocol for FederatedServiceRouter to use a function instead of a property to define the authURL.  Shopify requires the originating request URL to extract a param which is used as the host in the constructed AuthURL.

@robinsenior, can you try this on your app?