### PR TITLE
Add netID support

### DIFF
--- a/Sources/Imperial/Services/netID/NetID.swift
+++ b/Sources/Imperial/Services/netID/NetID.swift
@@ -20,7 +20,8 @@ public final class NetID: FederatedService {
             callback: callback,
             scope: scope,
             claims: [],
-            state: nil
+            state: nil,
+            stateVerify: nil
         )
         try self.init(router: router, config: config, completion: completion)
     }
@@ -34,6 +35,7 @@ public final class NetID: FederatedService {
         let netIDRouter = try NetIDRouter(callback: config.callback, completion: completion)
         netIDRouter.claims = config.claims
         netIDRouter.state = config.state
+        netIDRouter.stateVerify = config.stateVerify
         self.router = netIDRouter
         self.tokens = self.router.tokens
         

--- a/Sources/Imperial/Services/netID/NetID.swift
+++ b/Sources/Imperial/Services/netID/NetID.swift
@@ -1,0 +1,50 @@
+import Vapor
+
+public final class NetID: FederatedService {
+
+    public var tokens: FederatedServiceTokens
+    public var router: FederatedServiceRouter
+    
+    @discardableResult
+    public convenience init(
+        router: Router,
+        authenticate: String,
+        authenticateCallback: ((Request) throws -> (Future<Void>))?,
+        callback: String,
+        scope: [String] = [],
+        completion: @escaping (Request, String) throws -> (Future<ResponseEncodable>)
+    ) throws {
+        let config = NetIDConfig(
+            authenticate: authenticate,
+            authenticateCallback: authenticateCallback,
+            callback: callback,
+            scope: scope,
+            claims: [],
+            state: nil
+        )
+        try self.init(router: router, config: config, completion: completion)
+    }
+
+    @discardableResult
+    public init(
+        router: Router,
+        config: NetIDConfig,
+        completion: @escaping (Request, String) throws -> (Future<ResponseEncodable>)
+    ) throws {
+        let netIDRouter = try NetIDRouter(callback: config.callback, completion: completion)
+        netIDRouter.claims = config.claims
+        netIDRouter.state = config.state
+        self.router = netIDRouter
+        self.tokens = self.router.tokens
+        
+        self.router.scope = config.scope
+        try self.router.configureRoutes(
+            withAuthURL: config.authenticate,
+            authenticateCallback: config.authenticateCallback,
+            on: router
+        )
+        
+        OAuthService.register(.netid)
+    }
+
+}

--- a/Sources/Imperial/Services/netID/NetIDAuth.swift
+++ b/Sources/Imperial/Services/netID/NetIDAuth.swift
@@ -1,0 +1,18 @@
+import Vapor
+
+public class NetIDAuth: FederatedServiceTokens {
+
+    public static var idEnvKey: String = "NETID_CLIENT_ID"
+    public static var secretEnvKey: String = "NETID_CLIENT_SECRET"
+    public var clientID: String
+    public var clientSecret: String
+    
+    public required init() throws {
+        let idError = ImperialError.missingEnvVar(NetIDAuth.idEnvKey)
+        let secretError = ImperialError.missingEnvVar(NetIDAuth.secretEnvKey)
+        
+        self.clientID = try Environment.get(NetIDAuth.idEnvKey).value(or: idError)
+        self.clientSecret = try Environment.get(NetIDAuth.secretEnvKey).value(or: secretError)
+    }
+
+}

--- a/Sources/Imperial/Services/netID/NetIDCallbackBody.swift
+++ b/Sources/Imperial/Services/netID/NetIDCallbackBody.swift
@@ -1,0 +1,17 @@
+import Vapor
+
+struct NetIDCallbackBody: Content {
+
+    let code: String
+    let redirectURI: String
+    let grantType: String = "authorization_code"
+    
+    static var defaultContentType: MediaType = .urlEncodedForm
+    
+    enum CodingKeys: String, CodingKey {
+        case code = "code"
+        case redirectURI = "redirect_uri"
+        case grantType = "grant_type"
+    }
+
+}

--- a/Sources/Imperial/Services/netID/NetIDConfig.swift
+++ b/Sources/Imperial/Services/netID/NetIDConfig.swift
@@ -1,0 +1,28 @@
+import Vapor
+
+public struct NetIDConfig {
+
+    var authenticate: String
+    var authenticateCallback: ((Request) throws -> (Future<Void>))? = nil
+    var callback: String
+    var scope: [String] = []
+    var claims: [String] = []
+    var state: ((Request) throws -> String)? = nil
+
+    public init(
+        authenticate: String,
+        authenticateCallback: ((Request) throws -> (Future<Void>))? = nil,
+        callback: String,
+        scope: [String] = [],
+        claims: [String] = [],
+        state: ((Request) throws -> String)? = nil
+    ) {
+        self.authenticate = authenticate
+        self.authenticateCallback = authenticateCallback
+        self.callback = callback
+        self.scope = scope
+        self.claims = claims
+        self.state = state
+    }
+
+}

--- a/Sources/Imperial/Services/netID/NetIDConfig.swift
+++ b/Sources/Imperial/Services/netID/NetIDConfig.swift
@@ -2,12 +2,32 @@ import Vapor
 
 public struct NetIDConfig {
 
+    /// The route to register for the netID provider.
+    /// To start netID authentication navigate here.
     var authenticate: String
+
+    /// Something
     var authenticateCallback: ((Request) throws -> (Future<Void>))? = nil
+
+    /// The path or URL that netID will redirect to after authentication.
+    /// It is important that this URL is registered with netID.
     var callback: String
+
+    /// Scopes: List of identifiers used to specify what access privileges are requested for the access token.
+    /// Currently the only supported scope by netID is 'openid' which can be omitted because it will be added automatically.
     var scope: [String] = []
+
+    /// Claims: List of identifiers used to specify what attributes of the subject will be requested.
+    /// Currently supported claims by netID are 'gender', 'given_name', 'family_name', 'birthdate', 'email', 'email_verified' and 'address'.
     var claims: [String] = []
+
+    /// Closure which will be called to generate the value of the state parameter for each authentication.
+    /// It is highly recommended to specify this to mitigate CSRF attacks. The closure should return a string containing a unique and non-guessable value associated with each authentication.
     var state: ((Request) throws -> String)? = nil
+
+    /// Closure which will be called to verify the value of the state parameter returned by netID after an authentication.
+    /// It is mandatory to verify the state to mitigate CSRF attacks. With this closure this is done before an access token is requested. If omitted the verification MUST be performed in the completion handler of the authentication.
+    var stateVerify: ((Request, String) throws -> Bool)?
 
     public init(
         authenticate: String,
@@ -15,7 +35,8 @@ public struct NetIDConfig {
         callback: String,
         scope: [String] = [],
         claims: [String] = [],
-        state: ((Request) throws -> String)? = nil
+        state: ((Request) throws -> String)? = nil,
+        stateVerify: ((Request, String) throws -> Bool)? = nil
     ) {
         self.authenticate = authenticate
         self.authenticateCallback = authenticateCallback
@@ -23,6 +44,7 @@ public struct NetIDConfig {
         self.scope = scope
         self.claims = claims
         self.state = state
+        self.stateVerify = stateVerify
     }
 
 }

--- a/Sources/Imperial/Services/netID/NetIDRouter.swift
+++ b/Sources/Imperial/Services/netID/NetIDRouter.swift
@@ -1,0 +1,110 @@
+import Vapor
+import Foundation
+
+public class NetIDRouter: FederatedServiceRouter {
+
+    public let tokens: FederatedServiceTokens
+    public let callbackCompletion: (Request, String) throws -> (Future<ResponseEncodable>)
+    public var scope: [String] = []
+    public var claims: [String] = []
+    public var state: ((Request) throws -> String)?
+    public let callbackURL: String
+    public let accessTokenURL: String = "https://broker.netid.de/token"
+    
+    public required init(
+        callback: String,
+        completion: @escaping (Request, String) throws -> (Future<ResponseEncodable>)
+    ) throws {
+        self.tokens = try NetIDAuth()
+        self.callbackURL = callback
+        self.callbackCompletion = completion
+    }
+
+    private func scopeValue() throws -> String {
+        var scope = self.scope
+        if !scope.contains("openid") {
+            scope.append("openid")
+        }
+        return scope.joined(separator: " ")
+    }
+    
+    private func claimsValue() throws -> String {
+        var userinfo = [String: Any]()
+        for claim in claims {
+            userinfo[claim] = [ "essential": true ]
+        }
+        let claims: [String: Any] = [ "userinfo": userinfo ]
+        
+        guard let jsonData = try? JSONSerialization.data(withJSONObject: claims) else {
+            throw Abort(.badRequest, reason: "Encoding claims to JSON data failed!")
+        }
+        guard let jsonString = String(data: jsonData, encoding: .utf8) else {
+            throw Abort(.badRequest, reason: "Encoding claims to JSON string failed!")
+        }
+        return jsonString
+    }
+    
+    public func authURL(_ request: Request) throws -> String {
+        var url = URLComponents()
+        url.scheme = "https"
+        url.host = "broker.netid.de"
+        url.path = "/authorize"
+        var queryItems = [URLQueryItem]()
+        queryItems.append(URLQueryItem(name: "client_id", value: "\(self.tokens.clientID)"))
+        queryItems.append(URLQueryItem(name: "redirect_uri", value: "\(self.callbackURL)"))
+        queryItems.append(URLQueryItem(name: "scope", value: try scopeValue()))
+        queryItems.append(URLQueryItem(name: "claims", value: try claimsValue()))
+        queryItems.append(URLQueryItem(name: "response_type", value: "code"))
+        if let state = state {
+            let stateValue = try state(request)
+            queryItems.append(URLQueryItem(name: "state", value: stateValue))
+        }
+        url.queryItems = queryItems
+        guard let urlstring = url.string else {
+            throw Abort(.badRequest, reason: "Can't build authURL")
+        }
+        return urlstring
+    }
+    
+    public func fetchToken(from request: Request)throws -> Future<String> {
+        let code: String
+        if let queryCode: String = try request.query.get(at: "code") {
+            code = queryCode
+        } else if let error: String = try request.query.get(at: "error") {
+            throw Abort(.badRequest, reason: error)
+        } else {
+            throw Abort(.badRequest, reason: "Missing 'code' key in URL query")
+        }
+        
+        let body = NetIDCallbackBody(code: code, redirectURI: self.callbackURL)
+        return try body.encode(using: request).flatMap(to: Response.self) { request in
+            guard let url = URL(string: self.accessTokenURL) else {
+                throw Abort(.internalServerError, reason: "Unable to convert String '\(self.accessTokenURL)' to URL")
+            }
+            request.http.method = .POST
+            request.http.url = url
+            request.http.headers.basicAuthorization = BasicAuthorization(
+                username: self.tokens.clientID,
+                password: self.tokens.clientSecret
+            )
+            return try request.make(Client.self).send(request)
+        }.flatMap(to: String.self) { response in
+            return response.content.get(String.self, at: ["access_token"])
+        }
+    }
+    
+    public func callback(_ request: Request)throws -> Future<Response> {
+        return try self.fetchToken(from: request)
+            .flatMap(to: ResponseEncodable.self) { accessToken in
+                let session = try request.session()
+                
+                session.setAccessToken(accessToken)
+                try session.set("access_token_service", to: OAuthService.netid)
+                
+                return try self.callbackCompletion(request, accessToken)
+            }.flatMap(to: Response.self) { response in
+                return try response.encode(for: request)
+            }
+    }
+
+}

--- a/Sources/Imperial/Services/netID/NetIDRouter.swift
+++ b/Sources/Imperial/Services/netID/NetIDRouter.swift
@@ -31,12 +31,12 @@ public class NetIDRouter: FederatedServiceRouter {
     
     private func claimsValue() throws -> String {
         var userinfo = [String: Any]()
-        for claim in claims {
+        for claim in self.claims {
             userinfo[claim] = [ "essential": true ]
         }
-        let claims: [String: Any] = [ "userinfo": userinfo ]
+        let claimsInfo: [String: Any] = [ "userinfo": userinfo ]
         
-        guard let jsonData = try? JSONSerialization.data(withJSONObject: claims) else {
+        guard let jsonData = try? JSONSerialization.data(withJSONObject: claimsInfo) else {
             throw Abort(.badRequest, reason: "Encoding claims to JSON data failed!")
         }
         guard let jsonString = String(data: jsonData, encoding: .utf8) else {

--- a/Sources/Imperial/Services/netID/NetIDTokenRequestBody.swift
+++ b/Sources/Imperial/Services/netID/NetIDTokenRequestBody.swift
@@ -1,6 +1,6 @@
 import Vapor
 
-struct NetIDCallbackBody: Content {
+struct NetIDTokenRequestBody: Content {
 
     let code: String
     let redirectURI: String

--- a/Sources/Imperial/Services/netID/Service+NetID.swift
+++ b/Sources/Imperial/Services/netID/Service+NetID.swift
@@ -1,0 +1,8 @@
+extension OAuthService {
+    
+    public static let netid = OAuthService.init(
+        name: "netid",
+        endpoints: [:]
+    )
+    
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,10 +2,10 @@
 
 Below are links to the documentation to setup federated login with various OAuth providers that are supported.
 
-- [GitHub](docs/GitHub/README.md)
-- [Google](docs/Google/README.md)
-- [Shopify](docs/Shopify/README.md)
-- [Facebook](docs/Facebook/README.md)
-- [Keycloak](docs/Keycloak/README.md)
+- [GitHub](GitHub/README.md)
+- [Google](Google/README.md)
+- [Shopify](Shopify/README.md)
+- [Facebook](Facebook/README.md)
+- [Keycloak](Keycloak/README.md)
 - [netID](netID/README.md)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,8 +2,10 @@
 
 Below are links to the documentation to setup federated login with various OAuth providers that are supported.
 
-- [GitHub](https://github.com/vapor-community/Imperial/blob/master/docs/GitHub/README.md)
-- [Google](https://github.com/vapor-community/Imperial/blob/master/docs/Google/README.md)
-- [Shopify](https://github.com/vapor-community/Imperial/blob/master/docs/Shopify/README.md)
-- [Facebook](https://github.com/vapor-community/Imperial/tree/master/docs/Facebook/README.md)
-- [Keycloak](https://github.com/vapor-community/Imperial/tree/master/docs/Keycloak/README.md)
+- [GitHub](docs/GitHub/README.md)
+- [Google](docs/Google/README.md)
+- [Shopify](docs/Shopify/README.md)
+- [Facebook](docs/Facebook/README.md)
+- [Keycloak](docs/Keycloak/README.md)
+- [netID](netID/README.md)
+

--- a/docs/netID/README.md
+++ b/docs/netID/README.md
@@ -1,0 +1,45 @@
+# Federated Login with netID
+
+[netID](https://netid.de) is a federated european login service following the OIDC standard.
+
+To start go to https://developer.netid.de and create a service and a client for your project. For testing purposes you'll need to add at least one test user to the service. 
+Remember the Client ID and the Client secret created for your client.
+
+For integrating Imperial into your Vapor project follow the correspondent section in [Federated Login with Google](../Google/README.md).
+
+Imperial uses environment variables to access the client ID and secret to authenticate with netID. To allow Imperial to access these tokens, you will create these variables, called `NETID_CLIENT_ID` and `NETID_CLIENT_SECRET`, with the client ID and secret assigned to them. Imperial can then access these vars and use there values to authenticate with netID.
+
+Now, all you need to do is register the netID service in your main router method, like this:
+
+```swift
+let config = NetIDConfig(
+    authenticate: "netid/authenticate",
+    callback: "\(siteURL)/netid/authenticate-callback",
+    claims: ["given_name", "family_name", "email"],
+    state: { request in
+        guard let state = try create_state(on: request) else {
+            throw Abort(.internalServerError)
+        }
+        return state
+    }
+)
+try Imperial.NetID(router: router, config: config) { request, token in
+    // check state in request parameters if used
+    guard state_from_request == state_created_before else {
+         throw Abort(.forbidden)
+    }
+
+    print(token)
+
+    return Future(request.redirect(to: "/"))
+}
+```
+
+The `callback` argument is the URL you will go to when you want to authenticate the user. The `callback` argument has to be the same URL that you entered when you registered your client on netID.
+
+Using `claims` you can specify which information from the end user you want to retrieve.
+
+The optional `state` closure can be used to add a state parameter to the authorization request (see [State Parameter](https://auth0.com/docs/protocols/oauth2/oauth-state)). This parameter is returned on the `callback` uri and will be available on the request object given to the completion closure. If you want to use a state the `state` closure should return a string containing a unique and non-guessable value associated with each authentication. You MUST validate the state parameter in the completion handler.
+
+The completion handler is fired when the callback route is called by the login provider. The callback request and the access token is passed in and a response is returned.
+

--- a/docs/netID/README.md
+++ b/docs/netID/README.md
@@ -21,6 +21,9 @@ let config = NetIDConfig(
             throw Abort(.internalServerError)
         }
         return state
+    },
+    stateVerify: { request, state_from_request in
+        return state_from_request == state_created_before
     }
 )
 try Imperial.NetID(router: router, config: config) { request, token in
@@ -39,7 +42,7 @@ The `callback` argument is the URL you will go to when you want to authenticate 
 
 Using `claims` you can specify which information from the end user you want to retrieve.
 
-The optional `state` closure can be used to add a state parameter to the authorization request (see [State Parameter](https://auth0.com/docs/protocols/oauth2/oauth-state)). This parameter is returned on the `callback` uri and will be available on the request object given to the completion closure. If you want to use a state the `state` closure should return a string containing a unique and non-guessable value associated with each authentication. You MUST validate the state parameter in the completion handler.
+The optional `state` closure can be used to add a state parameter to the authorization request (see [State Parameter](https://auth0.com/docs/protocols/oauth2/oauth-state)). This parameter is returned on the `callback` uri and will be available on the request object given to the completion closure. If you want to use a state the `state` closure should return a string containing a unique and non-guessable value associated with each authentication. You can provide an optional closure `stateVerify` to verify the state returned by the provider before an access token gets requested. If you do not provide `stateVerify` you MUST validate the state parameter in the completion handler by yourself.
 
 The completion handler is fired when the callback route is called by the login provider. The callback request and the access token is passed in and a response is returned.
 


### PR DESCRIPTION
This adds support for netID service, which is a federated european login service following the OIDC standard. See https://developer.netid.de/ for more information and https://developer.netid.de/documentation/ for documentation.

netID is using claims instead of scopes, so I had to add support for claims to this service. For now I added this feature to this particular service only, and did not change the FederatedService protocol. Also, claims support is not complete because all claims are assumed to be essential.

Also, I added support for the state parameter, which should be supported by other services for security reasons, too, in my opinion. Again, because such a change should probably go along with a rework of the FederatedService interface I added it to the netID service, only.