### PR TITLE
Minimal refresh token support

### DIFF
--- a/Sources/Imperial/Helpers/Sessions+Imperial.swift
+++ b/Sources/Imperial/Helpers/Sessions+Imperial.swift
@@ -59,10 +59,10 @@ extension Session {
             if self[Keys.token] == nil {
                 throw Abort(.unauthorized, reason: "User currently not authenticated")
             } else {
-                let oauth_data = self["access_token_service"]?.data(using: .utf8) ?? Data()
-                let oauth = try? JSONSerialization.jsonObject(with: oauth_data, options: [])
-                let oauth_name = (oauth as? NSDictionary)?["name"] ?? "???"
-                throw Abort(.methodNotAllowed, reason: "OAuth provider '\(oauth_name)' uses no refresh tokens")
+                let oauthData = self["access_token_service"]?.data(using: .utf8) ?? Data()
+                let oauth = try? JSONSerialization.jsonObject(with: oauthData, options: [])
+                let oauthName = (oauth as? NSDictionary)?["name"] ?? "???"
+                throw Abort(.methodNotAllowed, reason: "OAuth provider '\(oauthName)' uses no refresh tokens")
             }
         }
         return token

--- a/Sources/Imperial/Helpers/Sessions+Imperial.swift
+++ b/Sources/Imperial/Helpers/Sessions+Imperial.swift
@@ -56,7 +56,14 @@ extension Session {
     /// - Throws: `Abort.unauthorized` if no refresh token exists.
     public func refreshToken()throws -> String {
         guard let token = self[Keys.refresh] else {
-            throw Abort(.unauthorized, reason: "User currently not authenticated")
+            if self[Keys.token] == nil {
+                throw Abort(.unauthorized, reason: "User currently not authenticated")
+            } else {
+                let oauth_data = self["access_token_service"]?.data(using: .utf8) ?? Data()
+                let oauth = try? JSONSerialization.jsonObject(with: oauth_data, options: [])
+                let oauth_name = (oauth as? NSDictionary)?["name"] ?? "???"
+                throw Abort(.methodNotAllowed, reason: "OAuth provider '\(oauth_name)' uses no refresh tokens")
+            }
         }
         return token
     }

--- a/Sources/Imperial/Helpers/Sessions+Imperial.swift
+++ b/Sources/Imperial/Helpers/Sessions+Imperial.swift
@@ -12,6 +12,16 @@ extension Request {
     public func accessToken()throws -> String {
         return try self.session().accessToken()
     }
+
+    /// Gets the refresh token from the current session.
+    ///
+    /// - Returns: The refresh token in the current session.
+    /// - Throws:
+    ///   - `Abort.unauthorized` if no refresh token exists.
+    ///   - `SessionsError.notConfigured` if session middlware is not configured yet.
+    public func refreshToken()throws -> String {
+        return try self.session().refreshToken()
+    }
 }
 
 extension Session {
@@ -19,12 +29,13 @@ extension Session {
     /// Keys used to store and retrieve items from the session
     enum Keys {
         static let token = "access_token"
+        static let refresh = "refresh_token"
     }
 
     /// Gets the access token from the session.
     ///
     /// - Returns: The access token stored with the `access_token` key.
-    /// - Throws: `Abort.unauthorized` if no access token exists.m
+    /// - Throws: `Abort.unauthorized` if no access token exists.
     public func accessToken()throws -> String {
         guard let token = self[Keys.token] else {
             throw Abort(.unauthorized, reason: "User currently not authenticated")
@@ -38,7 +49,25 @@ extension Session {
     public func setAccessToken(_ token: String) {
         self[Keys.token] = token
     }
-    
+
+    /// Gets the refresh token from the session.
+    ///
+    /// - Returns: The refresh token stored with the `refresh_token` key.
+    /// - Throws: `Abort.unauthorized` if no refresh token exists.
+    public func refreshToken()throws -> String {
+        guard let token = self[Keys.refresh] else {
+            throw Abort(.unauthorized, reason: "User currently not authenticated")
+        }
+        return token
+    }
+
+    /// Sets the refresh token on the session.
+    ///
+    /// - Parameter token: the refresh token to store on the session
+    public func setRefreshToken(_ token: String) {
+        self[Keys.refresh] = token
+    }
+
     /// Gets an object stored in a session with JSON as a given type.
     ///
     /// - Parameters:


### PR DESCRIPTION
Some OAuth providers use limited lifespan *access tokens*, along with long/indefinitely lived *refresh tokens*.

This PR implements the shared infrastructure needed for minimal refresh token support (Just storing the refresh token in the session). Currently my client implements the rest of the refreshing; I intend to eventually propose a PR to move that functionality to `Imperial` as well.