### PR TITLE
Use hexEncodedString() from Vapor to avoid duplicated hex() conflict

### DIFF
--- a/Sources/ImperialShopify/URL+Shopify.swift
+++ b/Sources/ImperialShopify/URL+Shopify.swift
@@ -10,7 +10,7 @@ extension URL {
 		let queryString = queryItems.joined(separator: "&")
 		
         let hmac = HMAC<SHA256>.authenticationCode(for: queryString.utf8, using: .init(data: Array(key.utf8)))
-		return hmac.hex
+        return hmac.hexEncodedString()
 	}
 
 	func isValidShopifyDomain() -> Bool {
@@ -20,22 +20,4 @@ extension URL {
 		
 		return absoluteString.range(of: "^[a-z0-9.-]+.myshopify.com$", options: .regularExpression) != nil
 	}
-}
-
-extension ContiguousBytes {
-    public var hex: String {
-        let table: [UInt8] = [
-            0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66
-        ]
-
-        return String(decoding: self.withUnsafeBytes { buffer in
-            Array<UInt8>.init(unsafeUninitializedCapacity: buffer.count * 2) { output, outCount in
-                outCount = buffer.reduce(into: 0) { count, byte in
-                    output[count + 0] = table[Int(byte / 16)]
-                    output[count + 1] = table[Int(byte % 16)]
-                    count += 2
-                }
-            }
-        }, as: Unicode.ASCII.self)
-    }
 }


### PR DESCRIPTION
A change begining with Vapor 4.0.0-rc.3.5 moves the `hex` extension property from `Collection` to `Sequence`, which makes it clash with Imperial's own `hex` extension property.

Note: Vapor also has `hex` which just calls `hexEncodedString()`. No idea if one should be preferred over the other.

Since Vapor is a dependency of Imperial, I figured out their implementation could just be reused here.