### PR TITLE
Test removing all brew commands

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,6 @@ jobs:
       DEVELOPER_DIR: /Applications/Xcode_11.4_beta.app/Contents/Developer
     steps:
     - uses: actions/checkout@v2
-    - run: brew install pkg-config
     - run: xcrun swift test --enable-test-discovery --sanitize=thread
   imperial_xenial:
     container: 


### PR DESCRIPTION
Since we don't need to link to libressl anymore, installing pkg-config is redundant so this should speed up CI