### PR TITLE
Microsoft: Support custom tenant IDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /*.xcodeproj
 build
 DerivedData/
+.swiftpm/

--- a/Sources/Imperial/Services/Microsoft/MicrosoftRouter.swift
+++ b/Sources/Imperial/Services/Microsoft/MicrosoftRouter.swift
@@ -2,12 +2,15 @@ import Vapor
 import Foundation
 
 public class MicrosoftRouter: FederatedServiceRouter {
+    public static var tenantIDEnvKey: String = "MICROSOFT_TENANT_ID"
+
     public let tokens: FederatedServiceTokens
     public let callbackCompletion: (Request, String)throws -> (Future<ResponseEncodable>)
     public var scope: [String] = []
     public let callbackURL: String
-    public let accessTokenURL: String = "https://login.microsoftonline.com/common/oauth2/v2.0/token"
-    
+    public var tenantID: String { Environment.get(MicrosoftRouter.tenantIDEnvKey) ?? "common" }
+    public var accessTokenURL: String { "https://login.microsoftonline.com/\(self.tenantID)/oauth2/v2.0/token" }
+
     public required init(
         callback: String,
         completion: @escaping (Request, String) throws -> (Future<ResponseEncodable>)
@@ -18,7 +21,7 @@ public class MicrosoftRouter: FederatedServiceRouter {
     }
 
     public func authURL(_ request: Request) throws -> String {
-        return "https://login.microsoftonline.com/common/oauth2/v2.0/authorize?"
+        return "https://login.microsoftonline.com/\(self.tenantID)/oauth2/v2.0/authorize?"
             + "client_id=\(self.tokens.clientID)&"
             + "response_type=code&"
             + "redirect_uri=\(self.callbackURL)&"


### PR DESCRIPTION
## Add support for Microsoft Tenant ID

In `MicrosoftRouter` the `accessTokenURL` was hardcoded to `https://login.microsoftonline.com/common/oauth2/v2.0/token`.

However, you can and should only use `common` if your app is configured as a multi-tenant application. For single-tenant applications you have to provide it in the `accessTokenURL`, e.g. `https://login.microsoftonline.com/f8cdef31-a31e-4b4a-93e4-89f11e91255a/oauth2/v2.0/token`, otherwise it fails with an error like this:

```
Application '(app ID)' is not configured as a multi-tenant application. Usage of the /common endpoint is not supported for such applications created after '10/15/2018'. Use a tenant-specific endpoint or configure the application to be multi-tenant."
```

This PR adds the possibility to change the tenant ID by providing it in `MICROSOFT_TENANT_ID` env var. If no tenant ID was provided it falls back to `common` (as before).

### Considerations

I would probably have `tenantID` added to `MicrosoftAuth` or `Microsoft`. But these have to conform to `FederatedServiceTokens` / `FederatedService` and I couldn't change their required initializers etc.

## Update `.gitignore`
Added .swiftpm folder to `.gitignore`