### PR TITLE
Update MicrosoftRouter endpoint

### DIFF
--- a/Sources/ImperialMicrosoft/MicrosoftRouter.swift
+++ b/Sources/ImperialMicrosoft/MicrosoftRouter.swift
@@ -26,7 +26,7 @@ public class MicrosoftRouter: FederatedServiceRouter {
     public func authURL(_ request: Request) throws -> String {
         var components = URLComponents()
         components.scheme = "https"
-        components.host = "www.login.microsoftonline.com"
+        components.host = "login.microsoftonline.com"
         components.path = "/\(tenantID)/oauth2/v2.0/authorize"
         components.queryItems = [
             clientIDItem,


### PR DESCRIPTION
A recent PR added a few `www` prefixes to some providers endpoints; in the case of Microsoft, it breaks it.

This PR remove the invalid `www` from the Microsoft oAuth login host.