### PR TITLE
fix callbackURL in DiscordRouter

### DIFF
--- a/Sources/ImperialDiscord/DiscordCallbackBody.swift
+++ b/Sources/ImperialDiscord/DiscordCallbackBody.swift
@@ -8,7 +8,6 @@ struct DiscordCallbackBody: Content {
     let grantType: String
     let code: String
     let redirectUri: String
-    let scope: String
 
     enum CodingKeys: String, CodingKey {
         case clientId = "client_id"
@@ -16,6 +15,5 @@ struct DiscordCallbackBody: Content {
         case grantType = "grant_type"
         case code
         case redirectUri = "redirect_uri"
-        case scope
     }
 }

--- a/docs/Discord/README.md
+++ b/docs/Discord/README.md
@@ -15,3 +15,9 @@ You can use Discord with the `ImperialDiscord` package. This expects two environ
 Additionally you must set `DiscordRouter.callbackURL` to an valid Redirect URL you added in the Developer Portal.
 
 You can then register the OAuth provider like normal.
+
+### References
+
+Some potentially useful references:
+
+* [Discord OAuth2 scopes](https://discord.com/developers/docs/topics/oauth2#shared-resources-oauth2-scopes)


### PR DESCRIPTION
* use the provided `callbackUrl` instead of always going to the default static `callbackUrl`
* add required scope to `DiscordRouter` — providing no scopes gives back an error, while providing at least one scope will always return `identify` scope together with the specified scopes
* remove unused scope property in `DiscordCallbackBody`
* add useful links to Discord Readme