### PR TITLE
Fix issue #43—Callback url registered incorrectly if using route groups

### DIFF
--- a/Sources/Imperial/Services/DeviantArt/DeviantArt.swift
+++ b/Sources/Imperial/Services/DeviantArt/DeviantArt.swift
@@ -6,6 +6,7 @@ public class DeviantArt: FederatedService {
 
     @discardableResult
     public required init(
+        grouped: [PathComponent],
         router: Router,
         authenticate: String,
         authenticateCallback: ((Request)throws -> (Future<Void>))?,
@@ -17,7 +18,7 @@ public class DeviantArt: FederatedService {
         self.tokens = self.router.tokens
 
         self.router.scope = scope
-        try self.router.configureRoutes(withAuthURL: authenticate, authenticateCallback: authenticateCallback, on: router)
+        try self.router.configureRoutes(grouped: grouped, withAuthURL: authenticate, authenticateCallback: authenticateCallback, on: router)
 
         OAuthService.register(.deviantart)
     }

--- a/Sources/Imperial/Services/Imgur/Imgur.swift
+++ b/Sources/Imperial/Services/Imgur/Imgur.swift
@@ -6,6 +6,7 @@ public class Imgur: FederatedService {
 
     @discardableResult
     public required init(
+        grouped: [PathComponent],
         router: Router,
         authenticate: String,
         authenticateCallback: ((Request)throws -> (Future<Void>))?,
@@ -17,7 +18,7 @@ public class Imgur: FederatedService {
         self.tokens = self.router.tokens
 
         self.router.scope = scope
-        try self.router.configureRoutes(withAuthURL: authenticate, authenticateCallback: authenticateCallback, on: router)
+        try self.router.configureRoutes(grouped: grouped, withAuthURL: authenticate, authenticateCallback: authenticateCallback, on: router)
 
         OAuthService.register(.imgur)
     }

--- a/Sources/Imperial/Services/Microsoft/Microsoft.swift
+++ b/Sources/Imperial/Services/Microsoft/Microsoft.swift
@@ -6,6 +6,7 @@ public class Microsoft: FederatedService {
     
     @discardableResult
     public required init(
+        grouped: [PathComponent],
         router: Router,
         authenticate: String,
         authenticateCallback: ((Request)throws -> (Future<Void>))?,
@@ -17,7 +18,7 @@ public class Microsoft: FederatedService {
         self.tokens = self.router.tokens
         
         self.router.scope = scope
-        try self.router.configureRoutes(withAuthURL: authenticate, authenticateCallback: authenticateCallback, on: router)
+        try self.router.configureRoutes(grouped: grouped, withAuthURL: authenticate, authenticateCallback: authenticateCallback, on: router)
         
         OAuthService.register(.microsoft)
     }

--- a/Sources/Imperial/Services/Mixcloud/Mixcloud.swift
+++ b/Sources/Imperial/Services/Mixcloud/Mixcloud.swift
@@ -8,6 +8,7 @@ public class Mixcloud: FederatedService {
 
     @discardableResult
     public required init(
+        grouped: [PathComponent],
         router: Router,
         authenticate: String,
         authenticateCallback: ((Request)throws -> (Future<Void>))?,
@@ -19,7 +20,7 @@ public class Mixcloud: FederatedService {
         self.tokens = self.router.tokens
 
         self.router.scope = scope
-        try self.router.configureRoutes(withAuthURL: authenticate, authenticateCallback: authenticateCallback, on: router)
+        try self.router.configureRoutes(grouped: grouped, withAuthURL: authenticate, authenticateCallback: authenticateCallback, on: router)
 
         OAuthService.register(.mixcloud)
         Mixcloud.instance = self

--- a/Sources/ImperialAuth0/Auth0.swift
+++ b/Sources/ImperialAuth0/Auth0.swift
@@ -7,6 +7,7 @@ public class Auth0: FederatedService {
     
     @discardableResult
     public required init(
+        grouped: [PathComponent],
         routes: RoutesBuilder,
         authenticate: String,
         authenticateCallback: ((Request) throws -> (EventLoopFuture<Void>))?,
@@ -18,7 +19,7 @@ public class Auth0: FederatedService {
         self.tokens = self.router.tokens
         
         self.router.scope = scope
-        try self.router.configureRoutes(withAuthURL: authenticate, authenticateCallback: authenticateCallback, on: routes)
+        try self.router.configureRoutes(grouped: grouped, withAuthURL: authenticate, authenticateCallback: authenticateCallback, on: routes)
         
         OAuthService.register(.auth0)
     }

--- a/Sources/ImperialCore/Helpers/String+Tools.swift
+++ b/Sources/ImperialCore/Helpers/String+Tools.swift
@@ -10,6 +10,7 @@ extension String {
                 .filter{ $0 != "/" }
                 .map{ .init(stringLiteral: $0) }
             if !grouped.isEmpty {
+                // find duplicate components at head of path
                 var indexes = IndexSet()
                 for (i, groupComponent) in grouped.enumerated() {
                     if i < pathComponentArray.count && groupComponent == pathComponentArray[i] {
@@ -18,7 +19,7 @@ extension String {
                         break   // after first component mismatch
                     }
                 }
-                // remove components at indexes in reverse order
+                // remove components
                 for index in indexes.reversed() {
                     pathComponentArray.remove(at: index)
                 }

--- a/Sources/ImperialCore/Helpers/String+Tools.swift
+++ b/Sources/ImperialCore/Helpers/String+Tools.swift
@@ -2,16 +2,30 @@ import Foundation
 import RoutingKit
 
 extension String {    
-	var pathComponents: [PathComponent] {
-		var pathComponentArray = [PathComponent]()
-		if let components = URL(string: self)?.pathComponents {
-			for item in components where item != "/" {
-				pathComponentArray.append(PathComponent(stringLiteral: item))
-			}
-		}
-		return pathComponentArray
-	}
-
+    func pathComponents(grouped: [PathComponent] = []) -> [PathComponent] {
+        var pathComponentArray = [PathComponent]()
+        if let url = URL(string: self) {
+            pathComponentArray = url
+                .pathComponents
+                .filter{ $0 != "/" }
+                .map{ .init(stringLiteral: $0) }
+            if !grouped.isEmpty {
+                var indexes = IndexSet()
+                for (i, groupComponent) in grouped.enumerated() {
+                    if i < pathComponentArray.count && groupComponent == pathComponentArray[i] {
+                        indexes.insert(i)   // duplicate at index
+                    } else {
+                        break   // after first component mismatch
+                    }
+                }
+                // remove components at indexes in reverse order
+                for index in indexes.reversed() {
+                    pathComponentArray.remove(at: index)
+                }
+            }
+        }
+        return pathComponentArray
+    }
 }
 
 extension String.UTF8View: DataProtocol {

--- a/Sources/ImperialCore/Routing/FederatedServiceRouter.swift
+++ b/Sources/ImperialCore/Routing/FederatedServiceRouter.swift
@@ -51,7 +51,7 @@ public protocol FederatedServiceRouter {
     ///   - authURL: The URL for the route that will redirect the user to the OAuth provider.
     ///   - authenticateCallback: Execute custom code within the authenticate closure before redirection.
     /// - Throws: N/A
-    func configureRoutes(withAuthURL authURL: String, authenticateCallback: ((Request) throws -> (EventLoopFuture<Void>))?, on router: RoutesBuilder) throws
+    func configureRoutes(grouped: [PathComponent], withAuthURL authURL: String, authenticateCallback: ((Request) throws -> (EventLoopFuture<Void>))?, on router: RoutesBuilder) throws
     
     /// Gets an access token from an OAuth provider.
     /// This method is the main body of the `callback` handler.
@@ -77,8 +77,8 @@ extension FederatedServiceRouter {
     public var errorKey: String { "error" }
     public var callbackHeaders: HTTPHeaders { [:] }
    
-    public func configureRoutes(withAuthURL authURL: String, authenticateCallback: ((Request) throws -> (EventLoopFuture<Void>))?, on router: RoutesBuilder) throws {
-		router.get(callbackURL.pathComponents, use: callback)
+    public func configureRoutes(grouped: [PathComponent], withAuthURL authURL: String, authenticateCallback: ((Request) throws -> (EventLoopFuture<Void>))?, on router: RoutesBuilder) throws {
+        router.get(callbackURL.pathComponents(grouped: grouped), use: callback)
 		router.get(authURL.pathComponents) { req -> EventLoopFuture<Response> in
             let redirect: Response = req.redirect(to: try self.authURL(req))
             guard let authenticateCallback = authenticateCallback else {

--- a/Sources/ImperialCore/Routing/FederatedServiceRouter.swift
+++ b/Sources/ImperialCore/Routing/FederatedServiceRouter.swift
@@ -79,7 +79,7 @@ extension FederatedServiceRouter {
    
     public func configureRoutes(grouped: [PathComponent], withAuthURL authURL: String, authenticateCallback: ((Request) throws -> (EventLoopFuture<Void>))?, on router: RoutesBuilder) throws {
         router.get(callbackURL.pathComponents(grouped: grouped), use: callback)
-		router.get(authURL.pathComponents) { req -> EventLoopFuture<Response> in
+		router.get(authURL.pathComponents()) { req -> EventLoopFuture<Response> in
             let redirect: Response = req.redirect(to: try self.authURL(req))
             guard let authenticateCallback = authenticateCallback else {
                 return req.eventLoop.makeSucceededFuture(redirect)

--- a/Sources/ImperialCore/ServiceRegister.swift
+++ b/Sources/ImperialCore/ServiceRegister.swift
@@ -6,6 +6,7 @@ extension RoutesBuilder {
     /// the parent route.
     ///
     /// - Parameters:
+    ///   - grouped: The path for grouped route. Duplicate components at head of callback url get removed when registering route.
     ///   - provider: The provider who's router will be used.
     ///   - authUrl: The path to navigate to authenticate.
     ///   - authenticateCallback: Execute custom code within the authenticate closure before redirection.
@@ -15,6 +16,7 @@ extension RoutesBuilder {
     ///   - completion: A callback with the current request and fetched
     ///     access token that is called when auth completes.
     public func oAuth<OAuthProvider>(
+        grouped: [PathComponent] = [],
         from provider: OAuthProvider.Type,
         authenticate authUrl: String,
         authenticateCallback: ((Request) throws -> (EventLoopFuture<Void>))? = nil,
@@ -23,6 +25,7 @@ extension RoutesBuilder {
         completion: @escaping (Request, String) throws -> EventLoopFuture<ResponseEncodable>
     ) throws where OAuthProvider: FederatedService {
         _ = try OAuthProvider(
+            grouped: grouped,
             routes: self,
             authenticate: authUrl,
             authenticateCallback: authenticateCallback,
@@ -44,6 +47,7 @@ extension RoutesBuilder {
     ///   - scope: The scopes to get access to on authentication.
     ///   - redirect: The path/URL to redirect to when auth completes.
     public func oAuth<OAuthProvider>(
+        grouped: [PathComponent] = [],
         from provider: OAuthProvider.Type,
         authenticate authUrl: String,
         authenticateCallback: ((Request) throws -> (EventLoopFuture<Void>))? = nil,
@@ -51,7 +55,7 @@ extension RoutesBuilder {
         scope: [String] = [],
         redirect redirectURL: String
     ) throws where OAuthProvider: FederatedService {
-        try self.oAuth(from: OAuthProvider.self, authenticate: authUrl, authenticateCallback: authenticateCallback, callback: callback, scope: scope) { (request, _) in
+        try self.oAuth(grouped: grouped, from: OAuthProvider.self, authenticate: authUrl, authenticateCallback: authenticateCallback, callback: callback, scope: scope) { (request, _) in
             let redirect: Response = request.redirect(to: redirectURL)
             return request.eventLoop.makeSucceededFuture(redirect)
         }

--- a/Sources/ImperialCore/Services/FederatedService.swift
+++ b/Sources/ImperialCore/Services/FederatedService.swift
@@ -13,12 +13,12 @@ public class Service: FederatedService {
     public var router: FederatedServiceRouter
 
     @discardableResult
-    public required init(authenticate: String, callback: String, scope: [String] = [], completion: @escaping (String) -> (ResponseRepresentable)) throws {
+    public required init(grouped: [PathComponent] = [], authenticate: String, callback: String, scope: [String] = [], completion: @escaping (String) -> (ResponseRepresentable)) throws {
         self.router = try ServiceRouter(callback: callback, completion: completion)
         self.tokens = self.router.tokens
 
         self.router.scope = scope
-        try self.router.configureRoutes(withAuthURL: authenticate, authenticateCallback: authenticateCallback, on: router)
+        try self.router.configureRoutes(grouped: grouped, withAuthURL: authenticate, authenticateCallback: authenticateCallback, on: router)
 
         Service.register(.service)
     }
@@ -42,5 +42,5 @@ public protocol FederatedService {
     ///   - scope: The scopes to send to the provider to request access to.
     ///   - completion: The completion handler that will fire at the end of the callback route. The access token is passed into the callback and the response that is returned will be returned from the callback route. This will usually be a redirect back to the app.
     /// - Throws: Any errors that occur in the implementation.
-    init(routes: RoutesBuilder, authenticate: String, authenticateCallback: ((Request) throws -> (EventLoopFuture<Void>))?, callback: String, scope: [String], completion: @escaping (Request, String) throws -> (EventLoopFuture<ResponseEncodable>)) throws
+    init(grouped: [PathComponent], routes: RoutesBuilder, authenticate: String, authenticateCallback: ((Request) throws -> (EventLoopFuture<Void>))?, callback: String, scope: [String], completion: @escaping (Request, String) throws -> (EventLoopFuture<ResponseEncodable>)) throws
 }

--- a/Sources/ImperialDiscord/Discord.swift
+++ b/Sources/ImperialDiscord/Discord.swift
@@ -7,6 +7,7 @@ public class Discord: FederatedService {
 
     @discardableResult
     public required init(
+        grouped: [PathComponent],
         routes: RoutesBuilder,
         authenticate: String,
         authenticateCallback: ((Request) throws -> (EventLoopFuture<Void>))?,
@@ -18,7 +19,7 @@ public class Discord: FederatedService {
         self.tokens = self.router.tokens
 
         self.router.scope = scope
-        try self.router.configureRoutes(withAuthURL: authenticate, authenticateCallback: authenticateCallback, on: routes)
+        try self.router.configureRoutes(grouped: grouped, withAuthURL: authenticate, authenticateCallback: authenticateCallback, on: routes)
 
         OAuthService.register(.discord)
     }

--- a/Sources/ImperialDropbox/Dropbox.swift
+++ b/Sources/ImperialDropbox/Dropbox.swift
@@ -7,6 +7,7 @@ public class Dropbox: FederatedService {
     
     @discardableResult
     public required init(
+        grouped: [PathComponent],
         routes: RoutesBuilder,
         authenticate: String,
         authenticateCallback: ((Request) throws -> (EventLoopFuture<Void>))?,
@@ -18,7 +19,7 @@ public class Dropbox: FederatedService {
         self.tokens = self.router.tokens
         
         self.router.scope = scope
-        try self.router.configureRoutes(withAuthURL: authenticate, authenticateCallback: authenticateCallback, on: routes)
+        try self.router.configureRoutes(grouped: grouped, withAuthURL: authenticate, authenticateCallback: authenticateCallback, on: routes)
         
         OAuthService.register(.dropbox)
     }

--- a/Sources/ImperialFacebook/Facebook.swift
+++ b/Sources/ImperialFacebook/Facebook.swift
@@ -7,6 +7,7 @@ public class Facebook: FederatedService {
 
     @discardableResult
     public required init(
+        grouped: [PathComponent],
         routes: RoutesBuilder,
         authenticate: String,
         authenticateCallback: ((Request) throws -> (EventLoopFuture<Void>))?,
@@ -18,7 +19,7 @@ public class Facebook: FederatedService {
         self.tokens = self.router.tokens
 
         self.router.scope = scope
-        try self.router.configureRoutes(withAuthURL: authenticate, authenticateCallback: authenticateCallback, on: routes)
+        try self.router.configureRoutes(grouped: grouped, withAuthURL: authenticate, authenticateCallback: authenticateCallback, on: routes)
 
         OAuthService.register(.facebook)
     }

--- a/Sources/ImperialGitHub/GitHub.swift
+++ b/Sources/ImperialGitHub/GitHub.swift
@@ -7,6 +7,7 @@ public class GitHub: FederatedService {
 
     @discardableResult
     public required init(
+        grouped: [PathComponent],
         routes: RoutesBuilder,
         authenticate: String,
         authenticateCallback: ((Request) throws -> (EventLoopFuture<Void>))?,
@@ -18,7 +19,7 @@ public class GitHub: FederatedService {
         self.tokens = self.router.tokens
 
         self.router.scope = scope
-        try self.router.configureRoutes(withAuthURL: authenticate, authenticateCallback: authenticateCallback, on: routes)
+        try self.router.configureRoutes(grouped: grouped, withAuthURL: authenticate, authenticateCallback: authenticateCallback, on: routes)
 
         OAuthService.register(.github)
     }

--- a/Sources/ImperialGitlab/Gitlab.swift
+++ b/Sources/ImperialGitlab/Gitlab.swift
@@ -7,6 +7,7 @@ public class Gitlab: FederatedService {
 
     @discardableResult
     public required init(
+        grouped: [PathComponent],
         routes: RoutesBuilder,
         authenticate: String,
         authenticateCallback: ((Request) throws -> (EventLoopFuture<Void>))?,
@@ -18,7 +19,7 @@ public class Gitlab: FederatedService {
         self.tokens = self.router.tokens
 
         self.router.scope = scope
-        try self.router.configureRoutes(withAuthURL: authenticate, authenticateCallback: authenticateCallback, on: routes)
+        try self.router.configureRoutes(grouped: grouped, withAuthURL: authenticate, authenticateCallback: authenticateCallback, on: routes)
 
         OAuthService.register(.gitlab)
     }

--- a/Sources/ImperialGoogle/JWT/GoogleJWT.swift
+++ b/Sources/ImperialGoogle/JWT/GoogleJWT.swift
@@ -6,6 +6,7 @@ public class GoogleJWT: FederatedService {
     
     @discardableResult
     public required init(
+        grouped: [PathComponent],
         routes: RoutesBuilder,
         authenticate: String,
         authenticateCallback: ((Request) throws -> (EventLoopFuture<Void>))?,
@@ -17,7 +18,7 @@ public class GoogleJWT: FederatedService {
         self.tokens = self.router.tokens
         
         self.router.scope = scope
-        try self.router.configureRoutes(withAuthURL: authenticate, authenticateCallback: authenticateCallback, on: routes)
+        try self.router.configureRoutes(grouped: grouped, withAuthURL: authenticate, authenticateCallback: authenticateCallback, on: routes)
         
         OAuthService.register(.google)
     }

--- a/Sources/ImperialGoogle/Standard/Google.swift
+++ b/Sources/ImperialGoogle/Standard/Google.swift
@@ -7,6 +7,7 @@ public class Google: FederatedService {
     
     @discardableResult
     public required init(
+        grouped: [PathComponent],
         routes: RoutesBuilder,
         authenticate: String,
         authenticateCallback: ((Request) throws -> (EventLoopFuture<Void>))?,
@@ -18,7 +19,7 @@ public class Google: FederatedService {
         self.tokens = self.router.tokens
         
         self.router.scope = scope
-        try self.router.configureRoutes(withAuthURL: authenticate, authenticateCallback: authenticateCallback, on: routes)
+        try self.router.configureRoutes(grouped: grouped, withAuthURL: authenticate, authenticateCallback: authenticateCallback, on: routes)
         
         OAuthService.register(.google)
     }

--- a/Sources/ImperialKeycloak/Keycloak.swift
+++ b/Sources/ImperialKeycloak/Keycloak.swift
@@ -7,6 +7,7 @@ public class Keycloak: FederatedService {
 
     @discardableResult
     public required init(
+        grouped: [PathComponent],
         routes: RoutesBuilder,
         authenticate: String,
         authenticateCallback: ((Request) throws -> (EventLoopFuture<Void>))?,
@@ -18,7 +19,7 @@ public class Keycloak: FederatedService {
         self.tokens = self.router.tokens
 
         self.router.scope = scope
-        try self.router.configureRoutes(withAuthURL: authenticate, authenticateCallback: authenticateCallback, on: routes)
+        try self.router.configureRoutes(grouped: grouped, withAuthURL: authenticate, authenticateCallback: authenticateCallback, on: routes)
 
         OAuthService.register(.keycloak)
     }

--- a/Sources/ImperialMicrosoft/Microsoft.swift
+++ b/Sources/ImperialMicrosoft/Microsoft.swift
@@ -7,6 +7,7 @@ public class Microsoft: FederatedService {
     
     @discardableResult
     public required init(
+        grouped: [PathComponent],
         routes: RoutesBuilder,
         authenticate: String,
         authenticateCallback: ((Request) throws -> (EventLoopFuture<Void>))?,
@@ -18,7 +19,7 @@ public class Microsoft: FederatedService {
         self.tokens = self.router.tokens
         
         self.router.scope = scope
-        try self.router.configureRoutes(withAuthURL: authenticate, authenticateCallback: authenticateCallback, on: routes)
+        try self.router.configureRoutes(grouped: grouped, withAuthURL: authenticate, authenticateCallback: authenticateCallback, on: routes)
         
         OAuthService.register(.microsoft)
     }

--- a/Sources/ImperialShopify/Shopify.swift
+++ b/Sources/ImperialShopify/Shopify.swift
@@ -9,7 +9,7 @@ public final class Shopify: FederatedService {
     public var shopifyRouter: ShopifyRouter
 
     public init(
-        grouped: [PathComponent] = [],
+        grouped: [PathComponent],
         routes: RoutesBuilder,
         authenticate: String,
         authenticateCallback: ((Request) throws -> (EventLoopFuture<Void>))?,

--- a/Sources/ImperialShopify/Shopify.swift
+++ b/Sources/ImperialShopify/Shopify.swift
@@ -9,6 +9,7 @@ public final class Shopify: FederatedService {
     public var shopifyRouter: ShopifyRouter
 
     public init(
+        grouped: [PathComponent] = [],
         routes: RoutesBuilder,
         authenticate: String,
         authenticateCallback: ((Request) throws -> (EventLoopFuture<Void>))?,
@@ -20,6 +21,7 @@ public final class Shopify: FederatedService {
         self.shopifyRouter.scope = scope
 
         try self.router.configureRoutes(
+            grouped: grouped,
             withAuthURL: authenticate,
             authenticateCallback: authenticateCallback,
             on: routes

--- a/Sources/ImperialShopify/ShopifyRouter.swift
+++ b/Sources/ImperialShopify/ShopifyRouter.swift
@@ -1,7 +1,6 @@
 import Vapor
 
 public class ShopifyRouter: FederatedServiceRouter {
-    
     public let tokens: FederatedServiceTokens
     public let callbackCompletion: (Request, String) throws -> (EventLoopFuture<ResponseEncodable>)
     public var scope: [String] = []

--- a/Tests/ImperialTests/ImperialTests.swift
+++ b/Tests/ImperialTests/ImperialTests.swift
@@ -1,10 +1,23 @@
 import XCTest
 @testable import ImperialCore
+@testable import Vapor
 
 class ImperialTests: XCTestCase {
     func testExists() {}
     
+    func testPathComponents() {
+        let callback = "http://localhost:8080/A/B/C"
+        XCTAssertEqual(callback.pathComponents(grouped: ["A"]).map{$0.description}.joined(), "BC")
+        XCTAssertEqual(callback.pathComponents(grouped: ["A", "B"]).map{$0.description}.joined(), "C")
+        XCTAssertEqual(callback.pathComponents(grouped: ["A", "B", "C"]).map{$0.description}.joined(), "")
+        XCTAssertEqual(callback.pathComponents(grouped: ["A", "B", "X"]).map{$0.description}.joined(), "C")
+        XCTAssertEqual(callback.pathComponents(grouped: ["X", "B", "C"]).map{$0.description}.joined(), "ABC")
+        XCTAssertEqual(callback.pathComponents(grouped: ["A", "X", "C"]).map{$0.description}.joined(), "BC")
+        XCTAssertEqual(callback.pathComponents(grouped: []).map{$0.description}.joined(), "ABC")
+    }
+    
     static var allTests: [(String, (ImperialTests) -> () -> ())] = [
-        ("testExists", testExists)
+        ("testExists", testExists),
+        ("testPathComponents", testPathComponents),
     ]
 }

--- a/Tests/ImperialTests/ImperialTests.swift
+++ b/Tests/ImperialTests/ImperialTests.swift
@@ -6,6 +6,8 @@ class ImperialTests: XCTestCase {
     
     func testPathComponents() {
         let callback = "http://localhost:8080/A/B/C"
+        XCTAssertEqual(callback.pathComponents(grouped: [":A"]).map{$0.description}.joined(), "ABC")
+        XCTAssertEqual(callback.pathComponents(grouped: ["*"]).map{$0.description}.joined(), "ABC")
         XCTAssertEqual(callback.pathComponents(grouped: ["A"]).map{$0.description}.joined(), "BC")
         XCTAssertEqual(callback.pathComponents(grouped: ["A", "B"]).map{$0.description}.joined(), "C")
         XCTAssertEqual(callback.pathComponents(grouped: ["A", "B", "C"]).map{$0.description}.joined(), "")

--- a/Tests/ImperialTests/ImperialTests.swift
+++ b/Tests/ImperialTests/ImperialTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 @testable import ImperialCore
-@testable import Vapor
 
 class ImperialTests: XCTestCase {
     func testExists() {}

--- a/Tests/ImperialTests/ImperialTests.swift
+++ b/Tests/ImperialTests/ImperialTests.swift
@@ -10,6 +10,7 @@ class ImperialTests: XCTestCase {
         XCTAssertEqual(callback.pathComponents(grouped: ["A"]).map{$0.description}.joined(), "BC")
         XCTAssertEqual(callback.pathComponents(grouped: ["A", "B"]).map{$0.description}.joined(), "C")
         XCTAssertEqual(callback.pathComponents(grouped: ["A", "B", "C"]).map{$0.description}.joined(), "")
+        XCTAssertEqual(callback.pathComponents(grouped: ["A", "B", "C", "D"]).map{$0.description}.joined(), "")
         XCTAssertEqual(callback.pathComponents(grouped: ["A", "B", "X"]).map{$0.description}.joined(), "C")
         XCTAssertEqual(callback.pathComponents(grouped: ["X", "B", "C"]).map{$0.description}.joined(), "ABC")
         XCTAssertEqual(callback.pathComponents(grouped: ["A", "X", "C"]).map{$0.description}.joined(), "BC")


### PR DESCRIPTION
Attempt to fix issue #43—Callback url registered incorrectly if using route groups.

It adds an optional parameter to `ServiceRegister` called `grouped: [PathComponent]`
```
oAuth<OAuthProvider>(
        grouped: [PathComponent] = [],
        ...
```

Can be used with group routes like this...
```
let abComponents: [PathComponent] = ["a", "b"]
let abRoutes = routes.grouped(abComponents)
try abRoutes.oAuth(
    grouped: abComponents,
    from: Google.self,
    authenticate: "start",
    callback: "http://localhost:8080/a/b/oauth/google",
    scope: ["profile", "email"],
    redirect: "/done")
    
 // call to trigger... http://localhost:8080/a/b/start
```
Ungroued routes can omit the parameter. So existing usage should not change.

The parameter is passed down to FederatedServiceRouter `configureRoutes(grouped:withAuthURL:authenticateCallback:on:)` where the callback URL gets registered.

When breaking the `callbackURL` into path components, duplicate components at the head of the path are removed. So the grouped route is registered properly and matches the callback url.

Most of the work happens inside `ImperialCore` > `Helpers` > `String + Tools.swift` > `pathComponents(grouped:)`

Also added a few tests for different kinds of groups and callback urls.

Happy to add readme stuff if you like the fix.