### PR TITLE
Make Swift Concurrently compatible by removing use of ThreadSpecificVariable

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,10 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.8
 import PackageDescription
 
 let package = Package(
     name: "Imperial",
     platforms: [
-       .macOS(.v10_15)
+        .macOS(.v12)
     ],
     products: [
         .library(name: "ImperialCore", targets: ["ImperialCore"]),

--- a/Sources/ImperialCore/ServiceRegister.swift
+++ b/Sources/ImperialCore/ServiceRegister.swift
@@ -21,8 +21,8 @@ extension RoutesBuilder {
         callback: String,
         scope: [String] = [],
         completion: @escaping (Request, String) throws -> EventLoopFuture<ResponseEncodable>
-    ) throws where OAuthProvider: FederatedService {
-        _ = try OAuthProvider(
+    ) throws -> OAuthProvider where OAuthProvider: FederatedService {
+        return try OAuthProvider(
             routes: self,
             authenticate: authUrl,
             authenticateCallback: authenticateCallback,
@@ -50,7 +50,7 @@ extension RoutesBuilder {
         callback: String,
         scope: [String] = [],
         redirect redirectURL: String
-    ) throws where OAuthProvider: FederatedService {
+    ) throws -> OAuthProvider where OAuthProvider: FederatedService {
         try self.oAuth(from: OAuthProvider.self, authenticate: authUrl, authenticateCallback: authenticateCallback, callback: callback, scope: scope) { (request, _) in
             let redirect: Response = request.redirect(to: redirectURL)
             return request.eventLoop.makeSucceededFuture(redirect)

--- a/Sources/ImperialCore/Services/OAuthService.swift
+++ b/Sources/ImperialCore/Services/OAuthService.swift
@@ -1,18 +1,8 @@
 import class NIO.ThreadSpecificVariable
 import Vapor
 
-fileprivate var services: ThreadSpecificVariable<OAuthServiceContainer> = .init(value: .init())
-
 /// Represents a service that interacts with an OAuth provider.
 public struct OAuthService: Codable, Content {
-
-    /// The services that are available for use in the application.
-    /// Services are added and fetched with the `Service.register` and `.get` static methods.
-    private static var services: OAuthServiceContainer {
-        get { ImperialCore.services.currentValue! }
-        set { ImperialCore.services.currentValue  = newValue }
-    }
-
 
     /// The name of the service, i.e. "google", "github", etc.
     public let name: String
@@ -51,34 +41,8 @@ public struct OAuthService: Codable, Content {
             endpoints[key] = newValue
         }
     }
-    
-    /// Registers a service as available for use.
-    ///
-    /// - Parameter service: The service to register.
+
+    @available(*, deprecated, message: "Register OAuth services with app.storage ")
     public static func register(_ service: OAuthService) {
-        #warning("It would be nice if this method could be internal")
-        self.services[service.name] = service
-    }
-    
-    /// Gets a service if it is available for use.
-    ///
-    /// - Parameter name: The name of the service to fetch.
-    /// - Returns: The service that matches the name passed in.
-    /// - Throws: `ImperialError.noServiceFound` if no service is found with the name passed in.
-    public static func get(service name: String) throws -> OAuthService {
-        return try self.services[name].value(or: ServiceError.noServiceFound(name))
-    }
-}
-
-private final class OAuthServiceContainer {
-    var services: [String: OAuthService]
-
-    init() {
-        self.services = [:]
-    }
-
-    subscript(service: String) -> OAuthService? {
-        get { self.services[service] }
-        set { self.services[service] = newValue }
     }
 }


### PR DESCRIPTION
I've been using a fork from @noli-ai that has been deleted or made private. This contained several fixes. In the interests of giving visibility to those fixes I'm opening this PR to address an issue that another committer found. This is not my work, but I am depending on these fixes in order to make Imperial usable in an async codebase.

Unfortunately I don't know much about the details of the changes – the commit/PR title is the only documentation I have available.

If there are small changes necessary to get this merged I'm happy to make them, but if this requires more work I'd rather leave this PR open for others who may need it until such time as #88 / #94 / #100 land.