### PR TITLE
More query items than just `scope`

### DIFF
--- a/Sources/ImperialAuth0/Auth0.swift
+++ b/Sources/ImperialAuth0/Auth0.swift
@@ -2,16 +2,24 @@
 import Vapor
 
 public struct Auth0: FederatedService {
+    public static func scopeQueryItem(_ scope: [String]) -> URLQueryItem {
+        var scope = scope
+        if !scope.contains("openid") {
+            scope += ["openid"]
+        }
+        return .init(name: "scope", value: scope.joined(separator: Self.scopeSeparator))
+    }
+    
     @discardableResult
     public init(
         routes: some RoutesBuilder,
         authenticate: String,
         authenticateCallback: (@Sendable (Request) async throws -> Void)?,
         callback: String,
-        scope: [String] = [],
-        completion: @escaping @Sendable (Request, String) async throws -> some AsyncResponseEncodable
+        queryItems: [URLQueryItem] = [],
+        completion: @escaping @Sendable (Request, String, ByteBuffer?) async throws -> some AsyncResponseEncodable
     ) throws {
-        try Auth0Router(callback: callback, scope: scope, completion: completion)
+        try Auth0Router(callback: callback, queryItems: queryItems, completion: completion)
             .configureRoutes(withAuthURL: authenticate, authenticateCallback: authenticateCallback, on: routes)
     }
 }

--- a/Sources/ImperialAuth0/Auth0Router.swift
+++ b/Sources/ImperialAuth0/Auth0Router.swift
@@ -2,48 +2,60 @@ import Foundation
 import Vapor
 
 struct Auth0Router: FederatedServiceRouter {
-    let baseURL: String
+    /// FederatedServiceRouter properties
     let tokens: any FederatedServiceTokens
-    let callbackCompletion: @Sendable (Request, String) async throws -> any AsyncResponseEncodable
-    let scope: [String]
-    let requiredScopes = ["openid"]
+    let callbackCompletion: @Sendable (Request, String, ByteBuffer?) async throws -> any AsyncResponseEncodable
     let callbackURL: String
     let accessTokenURL: String
     let callbackHeaders = HTTPHeaders([("Content-Type", "application/x-www-form-urlencoded")])
+    /// Local properties
+    let baseDomain: String
+    let queryItems: [URLQueryItem]
 
-    private func providerUrl(path: String) -> String {
-        return self.baseURL.finished(with: "/") + path
+    private static func providerURL(domain: String, path: String = "/oauth/token", queryItems: [URLQueryItem] = []) throws -> String {
+        guard let url = providerComponents(domain: domain, path: path, queryItems: queryItems).url?.absoluteString else {
+            throw Abort(.internalServerError)
+        }
+        return url
+    }
+    
+    private static func providerComponents(domain: String, path: String, queryItems: [URLQueryItem] = []) -> URLComponents {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = domain
+        components.path = path
+        components.queryItems = queryItems
+        return components
     }
 
     init(
-        callback: String, scope: [String], completion: @escaping @Sendable (Request, String) async throws -> some AsyncResponseEncodable
+        callback: String, queryItems: [URLQueryItem], completion: @escaping @Sendable (Request, String, ByteBuffer?) async throws -> some AsyncResponseEncodable
     ) throws {
-        let auth = try Auth0Auth()
-        self.tokens = auth
-        self.baseURL = "https://\(auth.domain)"
-        self.accessTokenURL = baseURL.finished(with: "/") + "oauth/token"
+        let tokens = try Auth0Auth()
+        self.tokens = tokens
+        self.baseDomain = tokens.domain
+        self.accessTokenURL = try Self.providerURL(domain: tokens.domain)
         self.callbackURL = callback
         self.callbackCompletion = completion
-        self.scope = scope
+        /// scope query item must contain `openid`
+        var queryItems = queryItems
+        if !queryItems.scope().contains("openid") {
+            queryItems.append(.init(name: "scope", value: "openid"))
+        }
+        self.queryItems = queryItems + [
+            .codeResponseTypeItem,
+            .init(clientID: tokens.clientID),
+            .init(redirectURIItem: callback),
+        ]
     }
 
-    func authURL(_ request: Request) throws -> String {
-        let path = "authorize"
-
-        var params = [
-            "response_type=code",
-            "client_id=\(self.tokens.clientID)",
-            "redirect_uri=\(self.callbackURL)",
-        ]
-
-        let allScopes = self.scope + self.requiredScopes
-        let scopeString = allScopes.joined(separator: " ").addingPercentEncoding(withAllowedCharacters: .urlHostAllowed)
-        if let scopes = scopeString {
-            params += ["scope=\(scopes)"]
-        }
-
-        let rtn = self.providerUrl(path: path + "?" + params.joined(separator: "&"))
-        return rtn
+    func authURLComponents(_ request: Request) throws -> URLComponents {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = baseDomain
+        components.path = "/authorize"
+        components.queryItems = self.queryItems
+        return components
     }
 
     func callbackBody(with code: String) -> any AsyncResponseEncodable {

--- a/Sources/ImperialCore/Array+URLQueryItem.swift
+++ b/Sources/ImperialCore/Array+URLQueryItem.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+extension Array where Element == URLQueryItem {
+    /// Finds first element named `scope` and returns its optional value as array of strings.
+    /// - Parameters:
+    ///  - separator: String to divide the optional query item value into an array.
+    public func scope(separatedBy separator: String = " ") -> [String] {
+        self.first(where: { $0.name == "scope" })?
+            .value?
+            .components(separatedBy: separator) ?? []
+    }
+}

--- a/Sources/ImperialCore/FederatedService.swift
+++ b/Sources/ImperialCore/FederatedService.swift
@@ -15,7 +15,6 @@ import Vapor
 ///         authenticate: String,
 ///         authenticateCallback: (@Sendable (Request) async throws -> Void)?,
 ///         callback: String,
-///         scope: [String] = [],
 ///         queryItems: [URLQueryItem],
 ///         completion: @escaping @Sendable (Request, String, ByteBuffer?) async throws -> some AsyncResponseEncodable
 ///     ) throws {

--- a/Sources/ImperialCore/FederatedService.swift
+++ b/Sources/ImperialCore/FederatedService.swift
@@ -16,7 +16,8 @@ import Vapor
 ///         authenticateCallback: (@Sendable (Request) async throws -> Void)?,
 ///         callback: String,
 ///         scope: [String] = [],
-///         completion: @escaping @Sendable (Request, String) async throws -> some AsyncResponseEncodable
+///         queryItems: [URLQueryItem],
+///         completion: @escaping @Sendable (Request, String, ByteBuffer?) async throws -> some AsyncResponseEncodable
 ///     ) throws {
 ///         try ServiceRouter(callback: callback, scope: scope, completion: completion)
 ///             .configureRoutes(withAuthURL: authenticate, authenticateCallback: authenticateCallback, on: routes)
@@ -24,6 +25,14 @@ import Vapor
 /// }
 /// ```
 public protocol FederatedService: Sendable {
+    /// Creates a scope query item.
+    /// - Parameters:
+    ///  - scope: An array of strings. Values may be unique to each provider.
+    static func scopeQueryItem(_ scope: [String]) -> URLQueryItem
+    
+    /// Separator used to combine scope values in provider URL.
+    static var scopeSeparator: String { get }
+
     /// Creates a service for getting an access token from an OAuth provider.
     ///
     /// - Parameters:
@@ -31,15 +40,38 @@ public protocol FederatedService: Sendable {
     ///   - authenticate: The path for the route that will redirect the user to the OAuth provider for authentication.
     ///   - authenticateCallback: Execute custom code within the authenticate closure before redirection.
     ///   - callback: The path (or URI) for the route that the provider will call when the user authenticates.
-    ///   - scope: The scopes to send to the provider to request access to.
-    ///   - completion: The completion handler that will fire at the end of the callback route. The access token is passed into the callback and the response that is returned will be returned from the callback route. This will usually be a redirect back to the app.
+    ///   - queryItems: Query items to send to the provider to request access to.
+    ///   - completion: The completion handler that will fire at the end of the callback route. The access token and optional response body are passed into the callback and the response that is returned will be returned from the callback route. This will usually be a redirect back to the app.
     /// - Throws: Any errors that occur in the implementation.
     @discardableResult init(
         routes: some RoutesBuilder,
         authenticate: String,
         authenticateCallback: (@Sendable (Request) async throws -> Void)?,
         callback: String,
-        scope: [String],
-        completion: @escaping @Sendable (Request, String) async throws -> some AsyncResponseEncodable
+        queryItems: [URLQueryItem],
+        completion: @escaping @Sendable (Request, String, ByteBuffer?) async throws -> some AsyncResponseEncodable
     ) throws
+    
+    /// Convert completion handler ByteBuffer into a string.
+    /// - Parameter buffer: ByteBuffer returned in completion handler.
+    /// - Returns: An optional string.
+    static func string(from buffer: ByteBuffer?) -> String?
+}
+
+extension FederatedService {
+    public static func scopeQueryItem(_ scope: [String]) -> URLQueryItem {
+        .init(
+            name: "scope",
+            value: scope
+                .map { $0.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? $0 }
+                .joined(separator: Self.scopeSeparator)
+        )
+    }
+    
+    public static var scopeSeparator: String { " " }
+    
+    public static func string(from buffer: ByteBuffer?) -> String? {
+        guard var buffer = buffer else { return nil }
+        return buffer.readString(length: buffer.readableBytes)
+    }
 }

--- a/Sources/ImperialCore/FederatedServiceRouter.swift
+++ b/Sources/ImperialCore/FederatedServiceRouter.swift
@@ -70,7 +70,12 @@ package protocol FederatedServiceRouter: Sendable {
     /// - Parameter request: The request from the OAuth provider.
     /// - Returns: A response that should redirect the user back to the app.
     /// - Throws: An errors that occur in the implementation code.
-    @Sendable func callback(_ request: Request) async throws -> Response    
+    @Sendable func callback(_ request: Request) async throws -> Response
+    
+    /// Retrieve refresh token from provider's response body.
+    /// - Parameter buffer: ByteBuffer returned by completion handler.
+    /// - Returns: An optional string.
+    func refreshToken(_ buffer: ByteBuffer?) -> String?
 }
 
 extension FederatedServiceRouter {
@@ -135,7 +140,14 @@ extension FederatedServiceRouter {
         let (accessToken, responseBody) = try await self.fetchTokenAndResponseBody(from: request)
         let session = request.session
         try session.setAccessToken(accessToken)
+        if let refreshToken = refreshToken(responseBody) {
+            session.setRefreshToken(refreshToken)
+        }
         let response = try await self.callbackCompletion(request, accessToken, responseBody)
         return try await response.encodeResponse(for: request)
-    }    
+    }
+    
+    package func refreshToken(_ responseBody: ByteBuffer?) -> String? {
+        return nil
+    }
 }

--- a/Sources/ImperialCore/FederatedServiceRouter.swift
+++ b/Sources/ImperialCore/FederatedServiceRouter.swift
@@ -9,11 +9,7 @@ package protocol FederatedServiceRouter: Sendable {
 
     /// The callback that is fired after the access token is fetched from the OAuth provider.
     /// The response that is returned from this callback is also returned from the callback route.
-    var callbackCompletion: @Sendable (Request, String) async throws -> any AsyncResponseEncodable { get }
-
-    /// The scopes to get permission for when getting the access token.
-    /// Usage of this property varies by provider.
-    var scope: [String] { get }
+    var callbackCompletion: @Sendable (Request, String, ByteBuffer?) async throws -> any AsyncResponseEncodable { get }
 
     /// The key to acess the code URL query parameter
     var codeKey: String { get }
@@ -30,20 +26,20 @@ package protocol FederatedServiceRouter: Sendable {
     /// The URL on the app that will redirect to the `authURL` to get the access token from the OAuth provider.
     var accessTokenURL: String { get }
 
-    /// The URL of the page that the user will be redirected to to get the access token.
-    func authURL(_ request: Request) throws -> String
-
+    /// The URL components of the page that the user will be redirected to to get the access token.
+    func authURLComponents(_ request: Request) throws -> URLComponents
+    
     /// Creates an instence of the type implementing the protocol.
     ///
     /// - Parameters:
     ///   - callback: The callback URL that the OAuth provider will redirect to after authenticating the user.
-    ///   - scope: The scopes to get access to on authentication.
-    ///   - completion: The completion handler that will be fired at the end of the `callback` route. The access token is passed into it.
+    ///   - queryItems: Additional query items sent to the provider.
+    ///   - completion: The completion handler that will be fired at the end of the `callback` route. The access token and response body are passed into it.
     /// - Throws: Any errors that could occur in the implementation.
     init(
         callback: String,
-        scope: [String],
-        completion: @escaping @Sendable (Request, String) async throws -> some AsyncResponseEncodable
+        queryItems: [URLQueryItem],
+        completion: @escaping @Sendable (Request, String, ByteBuffer?) async throws -> some AsyncResponseEncodable
     ) throws
 
     /// Configures the `authenticate` and `callback` routes with the droplet.
@@ -59,12 +55,12 @@ package protocol FederatedServiceRouter: Sendable {
         on router: some RoutesBuilder
     ) throws
 
-    /// Gets an access token from an OAuth provider.
+    /// Gets an access token and response body from an OAuth provider.
     /// This method is the main body of the `callback` handler.
     ///
     /// - Parameters: request: The request for the route
     ///   this method is called in.
-    func fetchToken(from request: Request) async throws -> String
+    func fetchTokenAndResponseBody(from request: Request) async throws -> (String, ByteBuffer?)
 
     /// Creates CallbackBody with authorization code
     func callbackBody(with code: String) -> any AsyncResponseEncodable
@@ -74,7 +70,7 @@ package protocol FederatedServiceRouter: Sendable {
     /// - Parameter request: The request from the OAuth provider.
     /// - Returns: A response that should redirect the user back to the app.
     /// - Throws: An errors that occur in the implementation code.
-    @Sendable func callback(_ request: Request) async throws -> Response
+    @Sendable func callback(_ request: Request) async throws -> Response    
 }
 
 extension FederatedServiceRouter {
@@ -87,7 +83,17 @@ extension FederatedServiceRouter {
     ) throws {
         router.get(callbackURL.pathSegments, use: callback)
         router.get(authURL.pathSegments) { req async throws -> Response in
-            let redirect: Response = req.redirect(to: try self.authURL(req))
+            /// add state query item to url
+            var authURLComponents = try authURLComponents(req)
+            let state = req.session.setState(count: 6)
+            if let queryItems = authURLComponents.queryItems {
+                authURLComponents.queryItems = queryItems + [.init(name: "state", value: state)]
+            }
+            // convert components to URL
+            guard let authURL = authURLComponents.url else {
+                throw Abort(.internalServerError)
+            }
+            let redirect: Response = req.redirect(to: authURL.absoluteString)
             guard let authenticateCallback else {
                 return redirect
             }
@@ -96,7 +102,9 @@ extension FederatedServiceRouter {
         }
     }
 
-    package func fetchToken(from request: Request) async throws -> String {
+    package func fetchTokenAndResponseBody(from request: Request) async throws -> (String, ByteBuffer?) {
+        /// verify state
+        try verifyState(request)
         let code: String
         if let queryCode: String = try request.query.get(at: codeKey) {
             code = queryCode
@@ -111,33 +119,23 @@ extension FederatedServiceRouter {
 
         let buffer = try await body.encodeResponse(for: request).body.buffer
         let response = try await request.client.post(url, headers: self.callbackHeaders) { $0.body = buffer }
-        return try response.content.get(String.self, at: ["access_token"])
+        let token = try response.content.get(String.self, at: ["access_token"])
+        return (token, response.body)
+    }
+    
+    package func verifyState(_ request: Request) throws {
+        guard let requestState = request.query[String.self, at: "state"],
+              let sessionState = request.session.state,
+              requestState == sessionState else {
+            throw Abort(.badRequest)
+        }
     }
 
     package func callback(_ request: Request) async throws -> Response {
-        let accessToken = try await self.fetchToken(from: request)
+        let (accessToken, responseBody) = try await self.fetchTokenAndResponseBody(from: request)
         let session = request.session
         try session.setAccessToken(accessToken)
-        let response = try await self.callbackCompletion(request, accessToken)
+        let response = try await self.callbackCompletion(request, accessToken, responseBody)
         return try await response.encodeResponse(for: request)
-    }
-}
-
-/// Convenience URLQueryItems
-extension FederatedServiceRouter {
-    package var clientIDItem: URLQueryItem {
-        .init(name: "client_id", value: tokens.clientID)
-    }
-
-    package var redirectURIItem: URLQueryItem {
-        .init(name: "redirect_uri", value: callbackURL)
-    }
-
-    package var scopeItem: URLQueryItem {
-        .init(name: "scope", value: scope.joined(separator: " "))
-    }
-
-    package var codeResponseTypeItem: URLQueryItem {
-        .init(name: "response_type", value: "code")
-    }
+    }    
 }

--- a/Sources/ImperialCore/RoutesBuilder+oAuth.swift
+++ b/Sources/ImperialCore/RoutesBuilder+oAuth.swift
@@ -1,7 +1,34 @@
 import Vapor
 
 extension RoutesBuilder {
-    /// Registers an OAuth provider's router with the parent route.
+    /// Registers an OAuth provider's router with the parent route and all provider options.
+    ///
+    /// - Parameters:
+    ///   - provider: The provider who's router will be used.
+    ///   - authUrl: The path to navigate to authenticate.
+    ///   - authenticateCallback: Execute custom code within the authenticate closure before redirection.
+    ///   - callback: The path or URL that the provider with redirect to when authentication completes.
+    ///   - queryItems: Query items appended to url provider's url.
+    ///   - completion: A callback with the current request, the fetched access token and response body that is called when auth completes.
+    public func oAuth<OAuthProvider>(
+        from provider: OAuthProvider.Type,
+        authenticate authUrl: String,
+        authenticateCallback: (@Sendable (Request) async throws -> Void)? = nil,
+        callback: String,
+        queryItems: [URLQueryItem] = [],
+        completion: @escaping @Sendable (Request, String, ByteBuffer?) async throws -> some AsyncResponseEncodable
+    ) throws where OAuthProvider: FederatedService {
+        try OAuthProvider(
+            routes: self,
+            authenticate: authUrl,
+            authenticateCallback: authenticateCallback,
+            callback: callback,
+            queryItems: queryItems,
+            completion: completion
+        )
+    }
+
+    /// Registers an OAuth provider's router with the parent route and just scope options.
     ///
     /// - Parameters:
     ///   - provider: The provider who's router will be used.
@@ -9,22 +36,18 @@ extension RoutesBuilder {
     ///   - authenticateCallback: Execute custom code within the authenticate closure before redirection.
     ///   - callback: The path or URL that the provider with redirect to when authentication completes.
     ///   - scope: The scopes to get access to on authentication.
-    ///   - completion: A callback with the current request and fetched access token that is called when auth completes.
+    ///   - completion: A callback with the current request, the fetched access token and response body that is called when auth completes.
     public func oAuth<OAuthProvider>(
         from provider: OAuthProvider.Type,
         authenticate authUrl: String,
         authenticateCallback: (@Sendable (Request) async throws -> Void)? = nil,
         callback: String,
         scope: [String] = [],
-        completion: @escaping @Sendable (Request, String) async throws -> some AsyncResponseEncodable
+        completion: @escaping @Sendable (Request, String, ByteBuffer?) async throws -> some AsyncResponseEncodable
     ) throws where OAuthProvider: FederatedService {
-        try OAuthProvider(
-            routes: self,
-            authenticate: authUrl,
-            authenticateCallback: authenticateCallback,
-            callback: callback,
-            scope: scope,
-            completion: completion
+        let queryItems = [provider.scopeQueryItem(scope)]
+        try self.oAuth(
+            from: OAuthProvider.self, authenticate: authUrl, authenticateCallback: authenticateCallback, callback: callback, queryItems: queryItems, completion: completion
         )
     }
 
@@ -47,7 +70,7 @@ extension RoutesBuilder {
     ) throws where OAuthProvider: FederatedService {
         try self.oAuth(
             from: OAuthProvider.self, authenticate: authUrl, authenticateCallback: authenticateCallback, callback: callback, scope: scope
-        ) { (request, _) in
+        ) { (request, _, _) in
             return request.redirect(to: redirectURL)
         }
     }

--- a/Sources/ImperialCore/Sessions+Imperial.swift
+++ b/Sources/ImperialCore/Sessions+Imperial.swift
@@ -21,6 +21,7 @@ extension Session {
     enum Keys {
         static let token = "access_token"
         static let refresh = "refresh_token"
+        static let state = "state"
     }
 
     /// Gets the access token from the session.
@@ -59,6 +60,23 @@ extension Session {
     /// - Parameter token: the refresh token to store on the session
     public func setRefreshToken(_ token: String) {
         self.data[Keys.refresh] = token
+    }
+    
+    /// Sets and returns random state value in the session.
+    ///
+    /// - Parameters:
+    ///   - count: Number of characters in returned string
+    public func setState(count: Int = 32) -> String {
+        let state = [UInt8].random(count: count).base64
+        self.data[Keys.state] = state
+        return state
+    }
+    
+    /// Retrieves and removes state value from the session.
+    public var state: String? {
+        let state = self.data[Keys.state]
+        self.data[Keys.state] = nil
+        return state
     }
 
     /// Gets an object stored in a session with JSON as a given type.

--- a/Sources/ImperialCore/URLQueryItem+Init.swift
+++ b/Sources/ImperialCore/URLQueryItem+Init.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Convenience initializers for FederatedServiceRouter
+extension URLQueryItem {
+    package init(clientID: String) {
+        self.init(name: "client_id", value: clientID)
+    }
+    
+    package init(redirectURIItem callbackURL: String) {
+        self.init(name: "redirect_uri", value: callbackURL)
+    }
+    
+    package static var codeResponseTypeItem: URLQueryItem {
+        .init(name: "response_type", value: "code")
+    }
+}

--- a/Sources/ImperialDeviantArt/DeviantArt.swift
+++ b/Sources/ImperialDeviantArt/DeviantArt.swift
@@ -8,10 +8,10 @@ public struct DeviantArt: FederatedService {
         authenticate: String,
         authenticateCallback: (@Sendable (Request) async throws -> Void)?,
         callback: String,
-        scope: [String] = [],
-        completion: @escaping @Sendable (Request, String) async throws -> some AsyncResponseEncodable
+        queryItems: [URLQueryItem] = [],
+        completion: @escaping @Sendable (Request, String, ByteBuffer?) async throws -> some AsyncResponseEncodable
     ) throws {
-        try DeviantArtRouter(callback: callback, scope: scope, completion: completion)
+        try DeviantArtRouter(callback: callback, queryItems: queryItems, completion: completion)
             .configureRoutes(withAuthURL: authenticate, authenticateCallback: authenticateCallback, on: routes)
     }
 }

--- a/Sources/ImperialDeviantArt/DeviantArtRouter.swift
+++ b/Sources/ImperialDeviantArt/DeviantArtRouter.swift
@@ -2,35 +2,38 @@ import Foundation
 import Vapor
 
 struct DeviantArtRouter: FederatedServiceRouter {
+    /// FederatedServiceRouter properties
     let tokens: any FederatedServiceTokens
-    let callbackCompletion: @Sendable (Request, String) async throws -> any AsyncResponseEncodable
-    let scope: [String]
+    let callbackCompletion: @Sendable (Request, String, ByteBuffer?) async throws -> any AsyncResponseEncodable
     let callbackURL: String
     let accessTokenURL: String = "https://www.deviantart.com/oauth2/token"
+    /// Local properties
+    let queryItems: [URLQueryItem]
 
     init(
-        callback: String, scope: [String], completion: @escaping @Sendable (Request, String) async throws -> some AsyncResponseEncodable
+        callback: String, queryItems: [URLQueryItem], completion: @escaping @Sendable (Request, String, ByteBuffer?) async throws -> some AsyncResponseEncodable
     ) throws {
         self.tokens = try DeviantArtAuth()
         self.callbackURL = callback
         self.callbackCompletion = completion
-        self.scope = scope
+        self.queryItems = queryItems + [
+            .codeResponseTypeItem,
+            .init(clientID: tokens.clientID),
+            .init(redirectURIItem: callback),
+        ]
     }
 
-    func authURL(_ request: Request) throws -> String {
-        let scope: String
-        if self.scope.count > 0 {
-            scope = "scope=" + self.scope.joined(separator: " ") + "&"
-        } else {
-            scope = ""
-        }
-        return "https://www.deviantart.com/oauth2/authorize?"
-            + "client_id=\(self.tokens.clientID)&"
-            + "redirect_uri=\(self.callbackURL)&\(scope)"
-            + "response_type=code"
+    func authURLComponents(_ request: Request) throws -> URLComponents {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = "www.deviantart.com"
+        components.path = "/oauth2/authorize"
+        components.queryItems = self.queryItems
+        return components
     }
 
-    func fetchToken(from request: Request) async throws -> String {
+    func fetchTokenAndResponseBody(from request: Request) async throws -> (String, ByteBuffer?) {
+        try verifyState(request)
         let code: String
         if let queryCode: String = try request.query.get(at: codeKey) {
             code = queryCode
@@ -49,7 +52,8 @@ struct DeviantArtRouter: FederatedServiceRouter {
         let refresh = try response.content.get(String.self, at: ["refresh_token"])
         request.session.setRefreshToken(refresh)
 
-        return try response.content.get(String.self, at: ["access_token"])
+        let token = try response.content.get(String.self, at: ["access_token"])
+        return (token, response.body)
     }
 
     func callbackBody(with code: String) -> any AsyncResponseEncodable {

--- a/Sources/ImperialDiscord/Discord.swift
+++ b/Sources/ImperialDiscord/Discord.swift
@@ -8,10 +8,10 @@ public struct Discord: FederatedService {
         authenticate: String,
         authenticateCallback: (@Sendable (Request) async throws -> Void)?,
         callback: String,
-        scope: [String] = [],
-        completion: @escaping @Sendable (Request, String) async throws -> some AsyncResponseEncodable
+        queryItems: [URLQueryItem] = [],
+        completion: @escaping @Sendable (Request, String, ByteBuffer?) async throws -> some AsyncResponseEncodable
     ) throws {
-        try DiscordRouter(callback: callback, scope: scope, completion: completion)
+        try DiscordRouter(callback: callback, queryItems: queryItems, completion: completion)
             .configureRoutes(withAuthURL: authenticate, authenticateCallback: authenticateCallback, on: routes)
     }
 }

--- a/Sources/ImperialDiscord/DiscordRouter.swift
+++ b/Sources/ImperialDiscord/DiscordRouter.swift
@@ -2,39 +2,38 @@ import Foundation
 import Vapor
 
 struct DiscordRouter: FederatedServiceRouter {
+    /// FederatedServiceRouter properties
     let tokens: any FederatedServiceTokens
-    let callbackCompletion: @Sendable (Request, String) async throws -> any AsyncResponseEncodable
-    let scope: [String]
+    let callbackCompletion: @Sendable (Request, String, ByteBuffer?) async throws -> any AsyncResponseEncodable
     let callbackURL: String
     let accessTokenURL: String = "https://discord.com/api/oauth2/token"
     let callbackHeaders = HTTPHeaders([("Content-Type", "application/x-www-form-urlencoded")])
+    /// Local properties
+    let scope: [String]
+    let queryItems: [URLQueryItem]
 
     init(
-        callback: String, scope: [String], completion: @escaping @Sendable (Request, String) async throws -> some AsyncResponseEncodable
+        callback: String, queryItems: [URLQueryItem], completion: @escaping @Sendable (Request, String, ByteBuffer?) async throws -> some AsyncResponseEncodable
     ) throws {
-        self.tokens = try DiscordAuth()
+        let tokens = try DiscordAuth()
+        self.tokens = tokens
         self.callbackURL = callback
         self.callbackCompletion = completion
-        self.scope = scope
+        self.scope = queryItems.scope()
+        self.queryItems = queryItems + [
+            .codeResponseTypeItem,
+            .init(clientID: tokens.clientID),
+            .init(redirectURIItem: callback),
+        ]
     }
 
-    func authURL(_ request: Request) throws -> String {
+    func authURLComponents(_ request: Request) throws -> URLComponents {
         var components = URLComponents()
         components.scheme = "https"
         components.host = "discord.com"
         components.path = "/api/oauth2/authorize"
-        components.queryItems = [
-            clientIDItem,
-            .init(name: "redirect_uri", value: self.callbackURL),
-            .init(name: "response_type", value: "code"),
-            scopeItem,
-        ]
-
-        guard let url = components.url else {
-            throw Abort(.internalServerError)
-        }
-
-        return url.absoluteString
+        components.queryItems = self.queryItems
+        return components
     }
 
     func callbackBody(with code: String) -> any AsyncResponseEncodable {

--- a/Sources/ImperialDropbox/Dropbox.swift
+++ b/Sources/ImperialDropbox/Dropbox.swift
@@ -8,10 +8,10 @@ public struct Dropbox: FederatedService {
         authenticate: String,
         authenticateCallback: (@Sendable (Request) async throws -> Void)?,
         callback: String,
-        scope: [String] = [],
-        completion: @escaping @Sendable (Request, String) async throws -> some AsyncResponseEncodable
+        queryItems: [URLQueryItem] = [],
+        completion: @escaping @Sendable (Request, String, ByteBuffer?) async throws -> some AsyncResponseEncodable
     ) throws {
-        try DropboxRouter(callback: callback, scope: scope, completion: completion)
+        try DropboxRouter(callback: callback, queryItems: queryItems, completion: completion)
             .configureRoutes(withAuthURL: authenticate, authenticateCallback: authenticateCallback, on: routes)
     }
 }

--- a/Sources/ImperialDropbox/DropboxRouter.swift
+++ b/Sources/ImperialDropbox/DropboxRouter.swift
@@ -2,45 +2,42 @@ import Foundation
 import Vapor
 
 struct DropboxRouter: FederatedServiceRouter {
+    /// FederatedServiceRouter properties
     let tokens: any FederatedServiceTokens
-    let callbackCompletion: @Sendable (Request, String) async throws -> any AsyncResponseEncodable
-    let scope: [String]
+    let callbackCompletion: @Sendable (Request, String, ByteBuffer?) async throws -> any AsyncResponseEncodable
     let callbackURL: String
     let accessTokenURL: String = "https://api.dropboxapi.com/oauth2/token"
-
     var callbackHeaders: HTTPHeaders {
         var headers = HTTPHeaders()
         headers.basicAuthorization = .init(username: tokens.clientID, password: tokens.clientSecret)
         headers.contentType = .urlEncodedForm
         return headers
     }
+    /// Local properties
+    let queryItems: [URLQueryItem]
+
 
     init(
-        callback: String, scope: [String], completion: @escaping @Sendable (Request, String) async throws -> some AsyncResponseEncodable
+        callback: String, queryItems: [URLQueryItem], completion: @escaping @Sendable (Request, String, ByteBuffer?) async throws -> some AsyncResponseEncodable
     ) throws {
-        self.tokens = try DropboxAuth()
+        let tokens = try DropboxAuth()
+        self.tokens = tokens
         self.callbackURL = callback
         self.callbackCompletion = completion
-        self.scope = scope
+        self.queryItems = queryItems + [
+            .codeResponseTypeItem,
+            .init(clientID: tokens.clientID),
+            .init(redirectURIItem: callback),
+        ]
     }
 
-    func authURL(_ request: Request) throws -> String {
+    func authURLComponents(_ request: Request) throws -> URLComponents {
         var components = URLComponents()
         components.scheme = "https"
         components.host = "www.dropbox.com"
         components.path = "/oauth2/authorize"
-        components.queryItems = [
-            clientIDItem,
-            redirectURIItem,
-            scopeItem,
-            codeResponseTypeItem,
-        ]
-
-        guard let url = components.url else {
-            throw Abort(.internalServerError)
-        }
-
-        return url.absoluteString
+        components.queryItems = self.queryItems
+        return components
     }
 
     func callbackBody(with code: String) -> any AsyncResponseEncodable {

--- a/Sources/ImperialFacebook/Facebook.swift
+++ b/Sources/ImperialFacebook/Facebook.swift
@@ -8,10 +8,10 @@ public struct Facebook: FederatedService {
         authenticate: String,
         authenticateCallback: (@Sendable (Request) async throws -> Void)?,
         callback: String,
-        scope: [String] = [],
-        completion: @escaping @Sendable (Request, String) async throws -> some AsyncResponseEncodable
+        queryItems: [URLQueryItem] = [],
+        completion: @escaping @Sendable (Request, String, ByteBuffer?) async throws -> some AsyncResponseEncodable
     ) throws {
-        try FacebookRouter(callback: callback, scope: scope, completion: completion)
+        try FacebookRouter(callback: callback, queryItems: queryItems, completion: completion)
             .configureRoutes(withAuthURL: authenticate, authenticateCallback: authenticateCallback, on: routes)
     }
 }

--- a/Sources/ImperialGitHub/GitHub.swift
+++ b/Sources/ImperialGitHub/GitHub.swift
@@ -8,10 +8,10 @@ public struct GitHub: FederatedService {
         authenticate: String,
         authenticateCallback: (@Sendable (Request) async throws -> Void)?,
         callback: String,
-        scope: [String] = [],
-        completion: @escaping @Sendable (Request, String) async throws -> some AsyncResponseEncodable
+        queryItems: [URLQueryItem] = [],
+        completion: @escaping @Sendable (Request, String, ByteBuffer?) async throws -> some AsyncResponseEncodable
     ) throws {
-        try GitHubRouter(callback: callback, scope: scope, completion: completion)
+        try GitHubRouter(callback: callback, queryItems: queryItems, completion: completion)
             .configureRoutes(withAuthURL: authenticate, authenticateCallback: authenticateCallback, on: routes)
     }
 }

--- a/Sources/ImperialGitlab/Gitlab.swift
+++ b/Sources/ImperialGitlab/Gitlab.swift
@@ -8,10 +8,10 @@ public struct Gitlab: FederatedService {
         authenticate: String,
         authenticateCallback: (@Sendable (Request) async throws -> Void)?,
         callback: String,
-        scope: [String] = [],
-        completion: @escaping @Sendable (Request, String) async throws -> some AsyncResponseEncodable
+        queryItems: [URLQueryItem] = [],
+        completion: @escaping @Sendable (Request, String, ByteBuffer?) async throws -> some AsyncResponseEncodable
     ) throws {
-        try GitlabRouter(callback: callback, scope: scope, completion: completion)
+        try GitlabRouter(callback: callback, queryItems: queryItems, completion: completion)
             .configureRoutes(withAuthURL: authenticate, authenticateCallback: authenticateCallback, on: routes)
     }
 }

--- a/Sources/ImperialGoogle/JWT/GoogleJWT.swift
+++ b/Sources/ImperialGoogle/JWT/GoogleJWT.swift
@@ -7,10 +7,10 @@ public struct GoogleJWT: FederatedService {
         authenticate: String,
         authenticateCallback: (@Sendable (Request) async throws -> Void)?,
         callback: String,
-        scope: [String] = [],
-        completion: @escaping @Sendable (Request, String) async throws -> some AsyncResponseEncodable
+        queryItems: [URLQueryItem] = [],
+        completion: @escaping @Sendable (Request, String, ByteBuffer?) async throws -> some AsyncResponseEncodable
     ) throws {
-        try GoogleJWTRouter(callback: callback, scope: scope, completion: completion)
+        try GoogleJWTRouter(callback: callback, queryItems: queryItems, completion: completion)
             .configureRoutes(withAuthURL: authenticate, authenticateCallback: authenticateCallback, on: routes)
     }
 }

--- a/Sources/ImperialGoogle/Standard/Google.swift
+++ b/Sources/ImperialGoogle/Standard/Google.swift
@@ -8,10 +8,25 @@ public struct Google: FederatedService {
         authenticate: String,
         authenticateCallback: (@Sendable (Request) async throws -> Void)?,
         callback: String,
-        scope: [String] = [],
-        completion: @escaping @Sendable (Request, String) async throws -> some AsyncResponseEncodable
+        queryItems: [URLQueryItem] = [],
+        completion: @escaping @Sendable (Request, String, ByteBuffer?) async throws -> some AsyncResponseEncodable
     ) throws {
-        try GoogleRouter(callback: callback, scope: scope, completion: completion)
+        try GoogleRouter(callback: callback, queryItems: queryItems, completion: completion)
             .configureRoutes(withAuthURL: authenticate, authenticateCallback: authenticateCallback, on: routes)
+    }
+}
+
+extension Google {
+    /// Convert completion handler ByteBuffer into a dicitonary
+    /// - Parameters:
+    ///  - from: ByteBuffer returned in completion handler.
+    public static func dictionary(_ buffer: ByteBuffer?) -> [String: Any]? {
+        guard let string = string(from: buffer),
+              let data = string.data(using: .utf8),
+              let dictionary = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return nil
+        }
+        return dictionary
     }
 }

--- a/Sources/ImperialGoogle/Standard/GoogleRouter.swift
+++ b/Sources/ImperialGoogle/Standard/GoogleRouter.swift
@@ -46,4 +46,11 @@ struct GoogleRouter: FederatedServiceRouter {
             redirectURI: callbackURL
         )
     }
+    
+    func refreshToken(_ buffer: ByteBuffer?) -> String? {
+        guard let dict = Google.dictionary(buffer) else {
+            return nil
+        }
+        return dict["refresh_token"] as? String
+    }
 }

--- a/Sources/ImperialImgur/Imgur.swift
+++ b/Sources/ImperialImgur/Imgur.swift
@@ -8,10 +8,10 @@ public struct Imgur: FederatedService {
         authenticate: String,
         authenticateCallback: (@Sendable (Request) async throws -> Void)?,
         callback: String,
-        scope: [String] = [],
-        completion: @escaping @Sendable (Request, String) async throws -> some AsyncResponseEncodable
+        queryItems: [URLQueryItem] = [],
+        completion: @escaping @Sendable (Request, String, ByteBuffer?) async throws -> some AsyncResponseEncodable
     ) throws {
-        try ImgurRouter(callback: callback, scope: scope, completion: completion)
+        try ImgurRouter(callback: callback, queryItems: queryItems, completion: completion)
             .configureRoutes(withAuthURL: authenticate, authenticateCallback: authenticateCallback, on: routes)
     }
 }

--- a/Sources/ImperialKeycloak/Keycloak.swift
+++ b/Sources/ImperialKeycloak/Keycloak.swift
@@ -8,10 +8,10 @@ public struct Keycloak: FederatedService {
         authenticate: String,
         authenticateCallback: (@Sendable (Request) async throws -> Void)?,
         callback: String,
-        scope: [String] = [],
-        completion: @escaping @Sendable (Request, String) async throws -> some AsyncResponseEncodable
+        queryItems: [URLQueryItem] = [],
+        completion: @escaping @Sendable (Request, String, ByteBuffer?) async throws -> some AsyncResponseEncodable
     ) throws {
-        try KeycloakRouter(callback: callback, scope: scope, completion: completion)
+        try KeycloakRouter(callback: callback, queryItems: queryItems, completion: completion)
             .configureRoutes(withAuthURL: authenticate, authenticateCallback: authenticateCallback, on: routes)
     }
 }

--- a/Sources/ImperialMicrosoft/Microsoft.swift
+++ b/Sources/ImperialMicrosoft/Microsoft.swift
@@ -8,10 +8,10 @@ public struct Microsoft: FederatedService {
         authenticate: String,
         authenticateCallback: (@Sendable (Request) async throws -> Void)?,
         callback: String,
-        scope: [String] = [],
-        completion: @escaping @Sendable (Request, String) async throws -> some AsyncResponseEncodable
+        queryItems: [URLQueryItem] = [],
+        completion: @escaping @Sendable (Request, String, ByteBuffer?) async throws -> some AsyncResponseEncodable
     ) throws {
-        try MicrosoftRouter(callback: callback, scope: scope, completion: completion)
+        try MicrosoftRouter(callback: callback, queryItems: queryItems, completion: completion)
             .configureRoutes(withAuthURL: authenticate, authenticateCallback: authenticateCallback, on: routes)
     }
 }

--- a/Sources/ImperialMicrosoft/MicrosoftRouter.swift
+++ b/Sources/ImperialMicrosoft/MicrosoftRouter.swift
@@ -3,45 +3,41 @@ import Vapor
 
 struct MicrosoftRouter: FederatedServiceRouter {
     static let tenantIDEnvKey: String = "MICROSOFT_TENANT_ID"
-
+    /// FederatedServiceRouter properties
     let tokens: any FederatedServiceTokens
-    let callbackCompletion: @Sendable (Request, String) async throws -> any AsyncResponseEncodable
-    let scope: [String]
+    let callbackCompletion: @Sendable (Request, String, ByteBuffer?) async throws -> any AsyncResponseEncodable
     let callbackURL: String
-    var tenantID: String { Environment.get(MicrosoftRouter.tenantIDEnvKey) ?? "common" }
     var accessTokenURL: String { "https://login.microsoftonline.com/\(self.tenantID)/oauth2/v2.0/token" }
     let errorKey = "error_description"
+    let isStateChecked = false
+    /// Local properties
+    var tenantID: String { Environment.get(MicrosoftRouter.tenantIDEnvKey) ?? "common" }
+    let scope: [String]
+    let queryItems: [URLQueryItem]
 
-    init(
-        callback: String,
-        scope: [String],
-        completion: @escaping @Sendable (Request, String) async throws -> some AsyncResponseEncodable
+    init(callback: String, queryItems: [URLQueryItem], completion: @escaping @Sendable (Request, String, ByteBuffer?) async throws -> some AsyncResponseEncodable
     ) throws {
-        self.tokens = try MicrosoftAuth()
+        let tokens = try MicrosoftAuth()
+        self.tokens = tokens
         self.callbackURL = callback
         self.callbackCompletion = completion
-        self.scope = scope
+        self.scope = queryItems.scope()
+        self.queryItems = queryItems + [
+            .codeResponseTypeItem,
+            .init(clientID: tokens.clientID),
+            .init(redirectURIItem: callback),
+            .init(name: "response_mode", value: "query"),
+            .init(name: "prompt", value: "consent"),
+        ]
     }
 
-    func authURL(_ request: Request) throws -> String {
+    func authURLComponents(_ request: Request) throws -> URLComponents {
         var components = URLComponents()
         components.scheme = "https"
         components.host = "login.microsoftonline.com"
         components.path = "/\(tenantID)/oauth2/v2.0/authorize"
-        components.queryItems = [
-            clientIDItem,
-            redirectURIItem,
-            scopeItem,
-            codeResponseTypeItem,
-            .init(name: "response_mode", value: "query"),
-            .init(name: "prompt", value: "consent"),
-        ]
-
-        guard let url = components.url else {
-            throw Abort(.internalServerError)
-        }
-
-        return url.absoluteString
+        components.queryItems = self.queryItems
+        return components
     }
 
     func callbackBody(with code: String) -> any AsyncResponseEncodable {

--- a/Sources/ImperialMixcloud/Mixcloud.swift
+++ b/Sources/ImperialMixcloud/Mixcloud.swift
@@ -8,10 +8,10 @@ public struct Mixcloud: FederatedService {
         authenticate: String,
         authenticateCallback: (@Sendable (Request) async throws -> Void)?,
         callback: String,
-        scope: [String] = [],
-        completion: @escaping @Sendable (Request, String) async throws -> some AsyncResponseEncodable
+        queryItems: [URLQueryItem] = [],
+        completion: @escaping @Sendable (Request, String, ByteBuffer?) async throws -> some AsyncResponseEncodable
     ) throws {
-        try MixcloudRouter(callback: callback, scope: scope, completion: completion)
+        try MixcloudRouter(callback: callback, queryItems: queryItems, completion: completion)
             .configureRoutes(withAuthURL: authenticate, authenticateCallback: authenticateCallback, on: routes)
     }
 }

--- a/Sources/ImperialMixcloud/MixcloudRouter.swift
+++ b/Sources/ImperialMixcloud/MixcloudRouter.swift
@@ -2,25 +2,37 @@ import Foundation
 import Vapor
 
 struct MixcloudRouter: FederatedServiceRouter {
+    /// FederatedServiceRouter properties
     let tokens: any FederatedServiceTokens
-    let callbackCompletion: @Sendable (Request, String) async throws -> any AsyncResponseEncodable
-    let scope: [String]
+    let callbackCompletion: @Sendable (Request, String, ByteBuffer?) async throws -> any AsyncResponseEncodable
     let callbackURL: String
     let accessTokenURL: String = "https://www.mixcloud.com/oauth/access_token"
+    let isStateChecked = false
+    /// Local properties
+    let queryItems: [URLQueryItem]
 
     init(
         callback: String,
-        scope: [String],
-        completion: @escaping @Sendable (Request, String) async throws -> some AsyncResponseEncodable
+        queryItems: [URLQueryItem],
+        completion: @escaping @Sendable (Request, String, ByteBuffer?) async throws -> some AsyncResponseEncodable
     ) throws {
-        self.tokens = try MixcloudAuth()
+        let tokens = try MixcloudAuth()
+        self.tokens = tokens
         self.callbackURL = callback
         self.callbackCompletion = completion
-        self.scope = scope
+        self.queryItems = queryItems + [
+            .init(clientID: tokens.clientID),
+            .init(redirectURIItem: callback),
+        ]
     }
 
-    func authURL(_ request: Request) throws -> String {
-        return "https://www.mixcloud.com/oauth/authorize?" + "client_id=\(self.tokens.clientID)&" + "redirect_uri=\(self.callbackURL)"
+    func authURLComponents(_ request: Request) throws -> URLComponents {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = "www.mixcloud.com"
+        components.path = "/oauth/authorize"
+        components.queryItems = self.queryItems
+        return components
     }
 
     func callbackBody(with code: String) -> any AsyncResponseEncodable {

--- a/Sources/ImperialShopify/Session+Shopify.swift
+++ b/Sources/ImperialShopify/Session+Shopify.swift
@@ -3,7 +3,6 @@ import Vapor
 extension Session {
     enum ShopifyKey {
         static let domain = "shop_domain"
-        static let nonce = "nonce"
     }
 
     var shopDomain: String {
@@ -17,13 +16,5 @@ extension Session {
 
     func setShopDomain(_ domain: String) throws {
         try self.set(ShopifyKey.domain, to: domain)
-    }
-
-    var nonce: String? {
-        try? self.get(ShopifyKey.nonce, as: String.self)
-    }
-
-    func setNonce(_ nonce: String?) throws {
-        try self.set(ShopifyKey.nonce, to: nonce)
     }
 }

--- a/Sources/ImperialShopify/Shopify.swift
+++ b/Sources/ImperialShopify/Shopify.swift
@@ -2,16 +2,18 @@
 import Vapor
 
 public struct Shopify: FederatedService {
+    public static var scopeSeparator: String { "," }
+    
     @discardableResult
     public init(
         routes: some RoutesBuilder,
         authenticate: String,
         authenticateCallback: (@Sendable (Request) async throws -> Void)?,
         callback: String,
-        scope: [String],
-        completion: @escaping @Sendable (Request, String) async throws -> some AsyncResponseEncodable
+        queryItems: [URLQueryItem] = [],
+        completion: @escaping @Sendable (Request, String, ByteBuffer?) async throws -> some AsyncResponseEncodable
     ) throws {
-        try ShopifyRouter(callback: callback, scope: scope, completion: completion)
+        try ShopifyRouter(callback: callback, queryItems: queryItems, completion: completion)
             .configureRoutes(
                 withAuthURL: authenticate,
                 authenticateCallback: authenticateCallback,

--- a/Sources/ImperialShopify/ShopifyRouter.swift
+++ b/Sources/ImperialShopify/ShopifyRouter.swift
@@ -1,46 +1,38 @@
 import Vapor
 
 struct ShopifyRouter: FederatedServiceRouter {
+    /// FederatedServiceRouter properties
     let tokens: any FederatedServiceTokens
-    let callbackCompletion: @Sendable (Request, String) async throws -> any AsyncResponseEncodable
-    let scope: [String]
+    let callbackCompletion: @Sendable (Request, String, ByteBuffer?) async throws -> any AsyncResponseEncodable
     let callbackURL: String
     // `accessTokenURL` used to be set inside `authURL` and read by `fetchToken`
     // now `fetchToken` creates the `accessTokenURL` itself from the shop domain in the request
     // but the property is still required by the protocol, so it's set to an empty string
     let accessTokenURL: String = ""
+    let isStateChecked = true
+    /// Local properties
+    let queryItems: [URLQueryItem]
 
     init(
-        callback: String, scope: [String], completion: @escaping @Sendable (Request, String) async throws -> some AsyncResponseEncodable
+        callback: String, queryItems: [URLQueryItem], completion: @escaping @Sendable (Request, String, ByteBuffer?) async throws -> some AsyncResponseEncodable
     ) throws {
-        self.tokens = try ShopifyAuth()
+        let tokens = try ShopifyAuth()
+        self.tokens = tokens
         self.callbackURL = callback
         self.callbackCompletion = completion
-        self.scope = scope
+        self.queryItems = queryItems + [
+            .init(clientID: tokens.clientID),
+            .init(redirectURIItem: callback),
+        ]
     }
 
-    func authURL(_ request: Request) throws -> String {
+    func authURLComponents(_ request: Request) throws -> URLComponents {
         guard let shop = request.query[String.self, at: "shop"] else { throw Abort(.badRequest) }
-
-        let nonce = String(UUID().uuidString.prefix(6))
-        try request.session.setNonce(nonce)
-
         var components = URLComponents()
         components.scheme = "https"
         components.host = shop
         components.path = "/admin/oauth/authorize"
-        components.queryItems = [
-            clientIDItem,
-            .init(name: "scope", value: scope.joined(separator: ",")),
-            redirectURIItem,
-            .init(name: "state", value: nonce),
-        ]
-
-        guard let url = components.url else {
-            throw Abort(.internalServerError)
-        }
-
-        return url.absoluteString
+        return components
     }
 
     func callbackBody(with code: String) -> any AsyncResponseEncodable {
@@ -55,18 +47,15 @@ struct ShopifyRouter: FederatedServiceRouter {
     /// This method is the main body of the `callback` handler.
     ///
     /// - Parameters: request: The request for the route this method is called in.
-    func fetchToken(from request: Request) async throws -> String {
+    func fetchTokenAndResponseBody(from request: Request) async throws -> (String, ByteBuffer?) {
+        // Verify the request
+        try verifyState(request)
         // Extract the parameters to verify
         guard let code = request.query[String.self, at: "code"],
             let shop = request.query[String.self, at: "shop"],
             let hmac = request.query[String.self, at: "hmac"]
         else { throw Abort(.badRequest) }
 
-        // Verify the request
-        if let state = request.query[String.self, at: "state"] {
-            let nonce = request.session.nonce
-            guard state == nonce else { throw Abort(.badRequest) }
-        }
         guard URL(string: shop)?.isValidShopifyDomain == true else { throw Abort(.badRequest) }
         guard URL(string: request.url.string)?.generateHMAC(key: tokens.clientSecret) == hmac else { throw Abort(.badRequest) }
 
@@ -75,7 +64,8 @@ struct ShopifyRouter: FederatedServiceRouter {
         let url = URI(string: "https://\(shop)/admin/oauth/access_token")
         let buffer = try await body.encodeResponse(for: request).body.buffer
         let response = try await request.client.post(url) { $0.body = buffer }
-        return try response.content.get(String.self, at: ["access_token"])
+        let token = try response.content.get(String.self, at: ["access_token"])
+        return (token, response.body)
     }
 
     /// The route that the OAuth provider calls when the user has benn authenticated.
@@ -84,13 +74,12 @@ struct ShopifyRouter: FederatedServiceRouter {
     /// - Returns: A response that should redirect the user back to the app.
     /// - Throws: Any errors that occur in the implementation code.
     func callback(_ request: Request) async throws -> Response {
-        let accessToken = try await self.fetchToken(from: request)
+        let (accessToken, responseBody) = try await self.fetchTokenAndResponseBody(from: request)
         let session = request.session
         guard let domain = request.query[String.self, at: "shop"] else { throw Abort(.badRequest) }
         try session.setAccessToken(accessToken)
         try session.setShopDomain(domain)
-        try session.setNonce(nil)
-        let response = try await self.callbackCompletion(request, accessToken)
+        let response = try await self.callbackCompletion(request, accessToken, responseBody)
         return try await response.encodeResponse(for: request)
     }
 }


### PR DESCRIPTION
The idea behind this pull request is allowing more query items than just scope.

I was trying to get a refresh token from Google and couldn't find a way to include the extra query item. I also couldn't find a way to retrieve it from the response.

So I forked and started marking changes. Here's a broad overview:

First, I added a more basic initializer that takes url query items instead of scope, since scope just becomes another query item. I also changed the completion handler to return the provider's response body as an optional ByteBuffer. The existing initializers just convert their scope parameter into a url query item and then supply it to the new one.

Second, I made changes to each provider. Some made urls via URLComponents and others via string methods. I changed them all to use URLComponents. And then I changed the FederatedServiceRouter variable authURL to authURLComponents. So the FederatedServiceRouter protocol extensions can get components from each provider and create the URL. As a result, error handling for that step is now in one place instead of duplicated across all providers.

Third, I looked at the online oAuth documentation for the providers and they recommend using a `state` URL query item. Since the FederatedServiceRouter protocol extension gets URL components now, it just adds a randomly generated state query item. And also saves that string value to the session. So when the response is received, comparing its state to the session state is easy.

Lastly, I added an example function to FederatedService protocol for converting the response body ByteBuffer in the completion handler to a string. I also added a function to the Google provider for converting a ByteBuffer into a dictionary.

I would be happy to do more if these proposals sound appealing. I have other ideas, but I don't want to waste your time.

Thanks for the very helpful code!